### PR TITLE
added custom SDA SCL pins for ESP32 I2C

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 
 .vscode/settings.json
 *.json
-*.json
-*.json
+__vm/*
+*.vcxproj*
+.vs/*
+Debug/*
+*.sln

--- a/Config.h
+++ b/Config.h
@@ -16,25 +16,25 @@
 // CONTROLLER ======================================================================================================================
 
 // PINMAP ---------------------------------------------------------- see https://onstep.groups.io/g/main/wiki/6-Configuration#PINMAP
-#define PINMAP                        OFF //    OFF, Choose from: MksGenL2, MiniPCB2, MaxPCB2, MaxESP3, CNC3, STM32Blue,     <-Req'd
+#define PINMAP                        MaxESP_RCX400 //    OFF, Choose from: MksGenL2, MiniPCB2, MaxPCB2, MaxESP3, CNC3, STM32Blue,     <-Req'd
                                           //         MaxSTM3, FYSETC_S6_2, etc.  Other boards and more info. in ~/src/Constants.h
 
 // SERIAL PORT COMMAND CHANNELS ------------------------------------ see https://onstep.groups.io/g/main/wiki/6-Configuration#SERIAL
 #define SERIAL_A_BAUD_DEFAULT        9600 //   9600, n. Where n=9600,19200,57600,115200,230400,460800 (common baud rates.)    Infreq
 #define SERIAL_B_BAUD_DEFAULT        9600 //   9600, n. Baud rate as above. See (src/pinmaps/) for Serial port assignments.   Option
-#define SERIAL_B_ESP_FLASHING         OFF //    OFF, ON Upload ESP8266 WiFi firmware through SERIAL_B with :ESPFLASH# cmd.    Option
+#define SERIAL_B_ESP_FLASHING         ON //    OFF, ON Upload ESP8266 WiFi firmware through SERIAL_B with :ESPFLASH# cmd.    Option
 #define SERIAL_C_BAUD_DEFAULT         OFF //    OFF, n. Baud rate as above. See (src/pinmaps/) for Serial port assignments.   Option
 #define SERIAL_D_BAUD_DEFAULT         OFF //    OFF, n. Baud rate as above. See (src/pinmaps/) for Serial port assignments.   Option
 
 // USER FEEDBACK -------------------------------------------- see https://onstep.groups.io/g/main/wiki/6-Configuration#USER_FEEDBACK
-#define STATUS_LED                    OFF //    OFF, Steady illumination if no error, blinks w/error code otherwise.          Option
+#define STATUS_LED                    ON //    OFF, Steady illumination if no error, blinks w/error code otherwise.          Option
 
 // RETICLE CONTROL ------------------------------------------------ see https://onstep.groups.io/g/main/wiki/6-Configuration#RETICLE
 #define RETICLE_LED_DEFAULT           OFF //    OFF, n. Where n=0..255 (0..100%) activates feature sets default brightness.   Option
 #define RETICLE_LED_MEMORY            OFF //    OFF, ON Remember reticle brightness across power cycles.                      Option
 
 // WEATHER SENSOR ------------------------------------------------- see https://onstep.groups.io/g/main/wiki/6-Configuration#SENSORS
-#define WEATHER                       OFF //    OFF, BME280 (I2C 0x77,) BME280_0x76, BME280_SPI (see pinmap for CS.)          Option
+#define WEATHER                       BME280_0x76 //    OFF, BME280 (I2C 0x77,) BME280_0x76, BME280_SPI (see pinmap for CS.)          Option
                                           //         BMP280 (I2C 0x77,) BMP280_0x76, BMP280_SPI (see pinmap for CS.)
                                           //         BME280 or BMP280 for temperature, pressure.  BME280 for humidity also.
 
@@ -50,18 +50,18 @@
 // Others: SERVO_II and SERVO_PD have settings in Extended.config.h
 
 // AXIS1 RA/AZM -------------------------------- see https://onstep.groups.io/g/main/wiki/Configuration---Rotator-and-Focusers#AXIS1
-#define AXIS1_DRIVER_MODEL            OFF //    OFF, Enter motor driver model (above) in both axes to activate the mount.    <-Often
+#define AXIS1_DRIVER_MODEL            GENERIC2_STEPDIR_SERVO //    OFF, Enter motor driver model (above) in both axes to activate the mount.    <-Often
 
 // If runtime axis settings are enabled changes in the section below may be ignored unless you reset to defaults:
 // \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ 
-#define AXIS1_STEPS_PER_DEGREE      12800 //  12800, n. Number of steps per degree:                                          <-Req'd
-                                          //         n = (stepper_steps * micro_steps * overall_gear_reduction)/360.0
+#define AXIS1_STEPS_PER_DEGREE      194.44444444  //  12800, n. Number of steps per degree:                                          <-Req'd
+                                                  //         n = (stepper_steps * micro_steps * overall_gear_reduction)/360.0
 #define AXIS1_REVERSE                 OFF //    OFF, ON Reverses movement direction, or reverse wiring instead to correct.   <-Often
 #define AXIS1_LIMIT_MIN              -180 //   -180, n. Where n= -90..-360 (degrees.) Minimum "Hour Angle" or Azimuth.        Adjust
 #define AXIS1_LIMIT_MAX               180 //    180, n. Where n=  90.. 360 (degrees.) Maximum "Hour Angle" or Azimuth.        Adjust
 
-#define AXIS1_DRIVER_MICROSTEPS        64 //    OFF, n. Microstep mode when tracking.                                        <-Req'd
-#define AXIS1_DRIVER_MICROSTEPS_GOTO    8 //    OFF, n. Microstep mode used during slews. OFF uses _DRIVER_MICROSTEPS.        Option
+#define AXIS1_DRIVER_MICROSTEPS        256 //    OFF, n. Microstep mode when tracking.                                        <-Req'd
+#define AXIS1_DRIVER_MICROSTEPS_GOTO    1 //    OFF, n. Microstep mode used during slews. OFF uses _DRIVER_MICROSTEPS.        Option
 
 // for TMC2130, TMC5160, TMC2209U, TMC2226U STEP/DIR driver models:
 #define AXIS1_DRIVER_IHOLD            OFF //    OFF, n, (mA.) Current during standstill. OFF uses IRUN/2.0                    Option
@@ -86,19 +86,22 @@
 
 #define AXIS1_WRAP                    OFF //    OFF, ON Allows unlimited RA/Azm range and ignores min/max/meridian limits.    Option
 
+#define AXIS1_ENABLE_STATE            HIGH                         // default state of ENable pin for motor power on
+#define AXIS1_SENSE_HOME_INIT         INPUT_PULLUP                // pin mode for home sensing
+
 // AXIS2 DEC/ALT ------------------------------- see https://onstep.groups.io/g/main/wiki/Configuration---Rotator-and-Focusers#AXIS2
-#define AXIS2_DRIVER_MODEL            OFF //    OFF, Enter motor driver model (above) in both axes to activate the mount.    <-Often
+#define AXIS2_DRIVER_MODEL            GENERIC2_STEPDIR_SERVO //    OFF, Enter motor driver model (above) in both axes to activate the mount.    <-Often
 
 // If runtime axis settings are enabled changes in the section below may be ignored unless you reset to defaults:
 // \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/
-#define AXIS2_STEPS_PER_DEGREE      12800 //  12800, n. Number of steps per degree:                                          <-Req'd
+#define AXIS2_STEPS_PER_DEGREE      194.44444444 //  12800, n. Number of steps per degree:                                          <-Req'd
                                           //         n = (stepper_steps * micro_steps * overall_gear_reduction)/360.0
-#define AXIS2_REVERSE                 OFF //    OFF, ON Reverses movement direction, or reverse wiring instead to correct.   <-Often
+#define AXIS2_REVERSE                 ON //    OFF, ON Reverses movement direction, or reverse wiring instead to correct.   <-Often
 #define AXIS2_LIMIT_MIN               -90 //    -90, n. Where n=-90..0 (degrees.) Minimum allowed declination.                Infreq
 #define AXIS2_LIMIT_MAX                90 //     90, n. Where n=0..90 (degrees.) Maximum allowed declination.                 Infreq
 
-#define AXIS2_DRIVER_MICROSTEPS        64 //    OFF, n. Microstep mode when tracking.                                        <-Often
-#define AXIS2_DRIVER_MICROSTEPS_GOTO    8 //    OFF, n. Microstep mode used during slews. OFF uses _DRIVER_MICROSTEPS.        Option
+#define AXIS2_DRIVER_MICROSTEPS        256 //    OFF, n. Microstep mode when tracking.                                        <-Often
+#define AXIS2_DRIVER_MICROSTEPS_GOTO    1 //    OFF, n. Microstep mode used during slews. OFF uses _DRIVER_MICROSTEPS.        Option
 
 // for TMC2130, TMC5160, and TMC2209U STEP/DIR driver models:
 #define AXIS2_DRIVER_IHOLD            OFF //    OFF, n, (mA.) Current during standstill. OFF uses IRUN/2.0                    Option
@@ -106,6 +109,7 @@
 #define AXIS2_DRIVER_IGOTO            OFF //    OFF, n, (mA.) Current during slews. OFF uses IRUN.                            Option
 // /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /
 
+#define AXIS2_HOME_DEFAULT            30
 #define AXIS2_DRIVER_STATUS           OFF //    OFF, ON, HIGH, or LOW.  Polling for driver status info/fault detection.       Option
 
 #define AXIS2_DRIVER_DECAY            OFF //    OFF, Tracking decay mode default override. TMC default is STEALTHCHOP.        Infreq
@@ -120,23 +124,26 @@
 #define AXIS2_TANGENT_ARM             OFF //    OFF, ON +limit range above. Set cntr w/[Reset Home] Return cntr w/[Find Home] Infreq
 #define AXIS2_TANGENT_ARM_CORRECTION  OFF //    OFF, ON enables tangent arm geometry correction for Axis2.                    Infreq
 
+#define AXIS2_ENABLE_STATE            HIGH                         // default state of ENable pin for motor power on
+#define AXIS2_SENSE_HOME_INIT         INPUT_PULLUP                // pin mode for home sensing
+
 // MOUNT ------------------------------------------------------- see https://onstep.groups.io/g/main/wiki/6-Configuration#MOUNT_TYPE
-#define MOUNT_TYPE                    GEM //    GEM, GEM for German Equatorial, FORK for Equatorial Fork, or ALTAZM          <-Req'd
+#define MOUNT_TYPE                    ALTAZM //    GEM, GEM for German Equatorial, FORK for Equatorial Fork, or ALTAZM          <-Req'd
                                           //         Dobsonian etc. mounts. GEM Eq mounts perform meridian flips.
 #define MOUNT_COORDS          TOPOCENTRIC // ...RIC, Applies refraction to coordinates to/from OnStep, except exactly         Infreq
                                           //              at the poles. Use TOPO_STRICT to apply refraction even in that case.
                                           //              Use OBSERVED_PLACE for no refraction.
 
 // TIME AND LOCATION -------------------------------------------------- see https://onstep.groups.io/g/main/wiki/6-Configuration#TLS
-#define TIME_LOCATION_SOURCE          OFF //    OFF, DS3231 (I2c,) DS3234 (Spi,) TEENSY (T3.2 internal,) or GPS source.       Option
+#define TIME_LOCATION_SOURCE          DS3231 //    OFF, DS3231 (I2c,) DS3234 (Spi,) TEENSY (T3.2 internal,) or GPS source.       Option
                                           //         Provides Date/Time, and if available, PPS & Lat/Long also.
-#define TIME_LOCATION_PPS_SENSE       OFF //    OFF, HIGH senses PPS (pulse per second,) signal rising edge, or use LOW for   Option
+#define TIME_LOCATION_PPS_SENSE       HIGH //    OFF, HIGH senses PPS (pulse per second,) signal rising edge, or use LOW for   Option
                                           //         falling edge, or use BOTH for rising and falling edges.
                                           //         Better tracking accuracy especially for Mega2560's w/ceramic resonator.
 
 // USER FEEDBACK -------------------------------------------- see https://onstep.groups.io/g/main/wiki/6-Configuration#USER_FEEDBACK
-#define STATUS_MOUNT_LED              OFF //    OFF, ON Flashes proportional to rate of movement or solid on for slews.       Option
-#define STATUS_BUZZER                 OFF //    OFF, ON, n. Where n=100..6000 (Hz freq.) for speaker. ON for piezo buzzer.    Option
+#define STATUS_MOUNT_LED              ON //    OFF, ON Flashes proportional to rate of movement or solid on for slews.       Option
+#define STATUS_BUZZER                 ON //    OFF, ON, n. Where n=100..6000 (Hz freq.) for speaker. ON for piezo buzzer.    Option
 #define STATUS_BUZZER_DEFAULT         OFF //    OFF, ON default starts w/buzzer enabled.                                      Option
 #define STATUS_BUZZER_MEMORY          OFF //    OFF, ON to remember buzzer setting across power cycles.                       Option
 
@@ -155,7 +162,7 @@
 #define GUIDE_SEPARATE_PULSE_RATE      ON //     ON, Uses a separate rate (stored in NV) for pulse guiding.                   Infreq
 
 // SENSORS -------------------------------------------------------- see https://onstep.groups.io/g/main/wiki/6-Configuration#SENSORS
-#define LIMIT_SENSE                   OFF //    OFF, HIGH or LOW state on limit sense switch stops movement.                  Option
+#define LIMIT_SENSE                   LOW //    OFF, HIGH or LOW state on limit sense switch stops movement.                  Option
 
 // PARK -------------------------------------------------------------- see https://onstep.groups.io/g/main/wiki/6-Configuration#PARK
 #define PARK_SENSE                    OFF //    OFF, HIGH or LOW state indicates mount is in the park orientation.            Option
@@ -164,8 +171,8 @@
 #define PARK_STRICT                   OFF //    OFF, ON Un-parking is only allowed if successfully parked.                    Option
 
 // PEC ---------------------------------------------------------------- see https://onstep.groups.io/g/main/wiki/6-Configuration#PEC
-#define PEC_STEPS_PER_WORM_ROTATION     0 //      0, n. Steps per worm rotation (0 disables else 720 sec buffer allocated.)  <-Req'd
                                           //         n = (AXIS1_STEPS_PER_DEGREE*360)/reduction_final_stage
+#define PEC_STEPS_PER_WORM_ROTATION   200 //      0, n. Steps per worm rotation (0 disables else 720 sec buffer allocated.)  <-Req'd
 
 #define PEC_SENSE                     OFF //    OFF, HIGH. Senses the PEC signal rising edge or use LOW for falling edge.     Option
                                           //         Ignored in ALTAZM mode.
@@ -181,7 +188,7 @@
 // SLEWING BEHAVIOUR ---------------------------------------------- see https://onstep.groups.io/g/main/wiki/6-Configuration#SLEWING
 #define SLEW_RATE_BASE_DESIRED        1.0 //    1.0, n. Desired slew rate in deg/sec. Adjustable at run-time from            <-Req'd
                                           //         1/2 to 2x this rate, and as performace considerations require.
-#define SLEW_RATE_MEMORY              OFF //    OFF, ON Remembers rates set across power cycles.                              Option
+#define SLEW_RATE_MEMORY              ON //    OFF, ON Remembers rates set across power cycles.                              Option
 #define SLEW_ACCELERATION_DIST        5.0 //    5.0, n, (degrees.) Approx. distance for acceleration (and deceleration.)      Adjust
 #define SLEW_RAPID_STOP_DIST          2.0 //    2.0, n, (degrees.) Approx. distance required to stop when a slew              Adjust
                                           //         is aborted or a limit is exceeded.
@@ -256,15 +263,15 @@
 // Others: SERVO_II and SERVO_PD have settings in Extended.config.h
 
 // AXIS4 FOCUSER 1 -------------------------------------------------- see https://onstep.groups.io/g/main/wiki/6-Configuration#AXIS4
-#define AXIS4_DRIVER_MODEL            OFF //    OFF, Enter motor driver model (above) to activate the focuser.                Option
+#define AXIS4_DRIVER_MODEL            GENERIC2_STEPDIR_SERVO //    OFF, Enter motor driver model (above) to activate the focuser.                Option
 #define AXIS4_SLEW_RATE_DESIRED       500 //    500, n, Where n=200..5000 (um/s.) Desired (maximum) microns/second.           Adjust
 
 // If runtime axis settings are enabled changes in the section below may be ignored unless you reset to defaults:
 // \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/ \/
-#define AXIS4_STEPS_PER_MICRON        0.5 //    0.5, n. Steps per micrometer. Figure this out by testing or other means.      Adjust
+#define AXIS4_STEPS_PER_MICRON        0.2 //    0.5, n. Steps per micrometer. Figure this out by testing or other means.      Adjust
 #define AXIS4_REVERSE                 OFF //    OFF, ON Reverses movement direction, or reverse wiring instead to correct.    Option
 #define AXIS4_LIMIT_MIN                 0 //      0, n. Where n=0..500 (millimeters.) Minimum allowed position.               Adjust
-#define AXIS4_LIMIT_MAX                50 //     50, n. Where n=0..500 (millimeters.) Maximum allowed position.               Adjust
+#define AXIS4_LIMIT_MAX                13 //     50, n. Where n=0..500 (millimeters.) Maximum allowed position.               Adjust
 
 #define AXIS4_DRIVER_MICROSTEPS       OFF //    OFF, n. Microstep mode when tracking.                                         Option
 #define AXIS4_DRIVER_MICROSTEPS_GOTO  OFF //    OFF, n. Microstep mode used during slews. OFF uses _DRIVER_MICROSTEPS.        Option
@@ -274,6 +281,7 @@
 #define AXIS4_DRIVER_IRUN             OFF //    OFF, n, (mA.) Current during tracking, appropriate for stepper/driver/etc.    Option
 #define AXIS4_DRIVER_IGOTO            OFF //    OFF, n, (mA.) Current during slews. OFF uses IRUN.                            Option
 // /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /\ /
+
 
 #define AXIS4_DRIVER_STATUS           OFF //    OFF, ON, HIGH, or LOW.  For driver status info/fault detection.               Option
 
@@ -286,7 +294,7 @@
 #define AXIS4_SENSE_LIMIT_MIN         OFF //    OFF, HIGH or LOW state on limit sense switch stops movement.                  Option
 #define AXIS4_SENSE_LIMIT_MAX         OFF //    OFF, HIGH or LOW state on limit sense switch stops movement.                  Option
 
-#define AXIS4_SLEW_RATE_MINIMUM         2 //      2, n. Where n=1..10 (um/s.) Minimum microns/second.                         Adjust
+#define AXIS4_SLEW_RATE_MINIMUM       500 //      2, n. Where n=1..10 (um/s.) Minimum microns/second.                         Adjust
 
 // FOCUSER USER FEEDBACK ------------------------------------ see https://onstep.groups.io/g/main/wiki/6-Configuration#USER_FEEDBACK
 #define STATUS_FOCUSER_LED            OFF //    OFF, ON Flashes proportional to the rate of movement (2Hz = 500um/s.)         Option
@@ -303,17 +311,18 @@
 // FEATURES ----------------------------------------------- see https://onstep.groups.io/g/main/wiki/6-ConfigurationMaster#AUXILIARY
 // Note: Temporarily set DEBUG mode to VERBOSE and use "FEATURE1_TEMP DS1820" to list the DS18B20 device serial numbers.
 
-#define FEATURE1_PURPOSE              OFF //    OFF, SWITCH, ANALOG_OUT, DEW_HEATER, INTERVALOMETER.                          Option
+#define FEATURE1_PURPOSE              SWITCH //    OFF, SWITCH, ANALOG_OUT, DEW_HEATER, INTERVALOMETER.                          Option
 #define FEATURE1_NAME          "FEATURE1" // "FE..", Name of feature being controlled.                                        Adjust
 #define FEATURE1_TEMP                 OFF //    OFF, THERMISTOR or n. Where n is the ds18b20 s/n. For DEW_HEATER temperature. Adjust
+#define FEATURE1_PIN                  512 //    OFF, AUX for auxiliary pin, n. Where n is the pin#.                           Adjust
 #define FEATURE1_PIN                  OFF //    OFF, AUX for auxiliary pin, n. Where n is the pin#.                           Adjust
 #define FEATURE1_VALUE_DEFAULT        OFF //    OFF, ON, n. Where n=0..255 for ANALOG_OUT purpose.                            Adjust
 #define FEATURE1_ON_STATE            HIGH //   HIGH, LOW to invert so "ON" is 0V and "OFF" is Vcc (3.3V usually.)             Adjust
 
-#define FEATURE2_PURPOSE              OFF //    OFF, SWITCH, ANALOG_OUT, DEW_HEATER, INTERVALOMETER.                          Option
-#define FEATURE2_NAME          "FEATURE2" // "FE..", Name of feature being controlled.                                        Adjust
+#define FEATURE2_PURPOSE              SWITCH //    OFF, SWITCH, ANALOG_OUT, DEW_HEATER, INTERVALOMETER.                          Option
+#define FEATURE2_NAME          "FAN" // "FE..", Name of feature being controlled.                                        Adjust
 #define FEATURE2_TEMP                 OFF //    OFF, THERMISTOR or n. Where n is the ds18b20 s/n. For DEW_HEATER temperature. Adjust
-#define FEATURE2_PIN                  OFF //    OFF, AUX for auxiliary pin, n. Where n is the pin#.                           Adjust
+#define FEATURE2_PIN                  516 //    OFF, AUX for auxiliary pin, n. Where n is the pin#.                           Adjust
 #define FEATURE2_VALUE_DEFAULT        OFF //    OFF, ON, n. Where n=0..255 for ANALOG_OUT purpose.                            Adjust
 #define FEATURE2_ON_STATE            HIGH //   HIGH, LOW to invert so "ON" is 0V and "OFF" is Vcc (3.3V usually.)             Adjust
 

--- a/Extended.config.h
+++ b/Extended.config.h
@@ -18,7 +18,7 @@
 // DEBUG ------------------------------------------------------------ see https://onstep.groups.io/g/main/wiki/6-Configuration#DEBUG
 // Enable additional debugging and/or status messages on the specified SERIAL_DEBUG port
 // Note that the SERIAL_DEBUG port cannot be used for normal communication with OnStep
-#define DEBUG                         OFF //    OFF, Use ON for background error messages only, use VERBOSE for all           Infreq
+#define DEBUG                         VERBOSE //    OFF, Use ON for background error messages only, use VERBOSE for all           Infreq
                                           //         error and status messages, use CONSOLE for VT100 debug console,
                                           //         or use PROFILER for VT100 task profiler.
 #define DEBUG_SERVO                   OFF //    OFF, n. Where n=1 to 9 as the designated axis for logging servo activity.     Option
@@ -27,12 +27,12 @@
 #define SERIAL_DEBUG_BAUD            9600 //   9600, n. Where n=9600,19200,57600,115200 (common baud rates.)                  Option
 
 // ESP32 VIRTUAL SERIAL BLUETOOTH AND IP COMMAND CHANNELS --------------------------------------------------------------------------
-#define SERIAL_BT_MODE                OFF //    OFF, Use SLAVE to enable the interface (ESP32 only.)                          Option
+#define SERIAL_BT_MODE                SLAVE //    OFF, Use SLAVE to enable the interface (ESP32 only.)                          Option
 #define SERIAL_BT_NAME          "OnStepX" //         "OnStepX", Bluetooth device name.                                        Adjust
 #define SERIAL_IP_MODE                OFF //    OFF, Use ACCESS_POINT or STATION to enable the interface (ESP32 only.)        Option
 
 // EXTERNAL GPIO SUPPORT -----------------------------------------------------------------------------------------------------------
-#define GPIO_DEVICE                   OFF //    OFF, DS2413 for 2-ch 1-wire GPIO, MCP23008 for 8-ch I2C GPIO, or MCP23017     Option
+#define GPIO_DEVICE                   MCP23017 //    OFF, DS2413 for 2-ch 1-wire GPIO, MCP23008 for 8-ch I2C GPIO, or MCP23017     Option
                                           //         for a 16-ch I2C GPIO. The device can be used for most OnStep features.
                                           //         Channels are assigned to pin#'s starting at 512 (for channel 0, etc.)
 

--- a/src/Constants.h
+++ b/src/Constants.h
@@ -27,8 +27,9 @@
 #define CNC3                        14     // Arduino CNC Sheild on WeMos D1 R32 (ESP32)
 
 #define STM32Blue                   15     // Khalid and Dave's PCB for STM32 Blue pill (STM32F103CB and STM32F303CC)
+#define MaxESP_RCX400               16     // adds 4th axis and option to flash the WeMos D1 Mini WiFi through OnStep
 
-#define PINMAP_LAST                 15
+#define PINMAP_LAST                 16
 
 // WEATHER sensors (temperature, pressure, and humidity)
 #define WEATHER_FIRST               1

--- a/src/HAL/HAL_ESP32.h
+++ b/src/HAL/HAL_ESP32.h
@@ -50,9 +50,20 @@
   #error "Configuration (Config.h): SERIAL_BT_MODE and SERIAL_IP_MODE can't be enabled at the same time, disable one or both options."
 #endif
 
+#if (defined(SDA_PIN) && defined(SCL_PIN))
+  #define beginWire() HAL_Wire.begin(SDA_PIN, SCL_PIN, HAL_WIRE_CLOCK);
+#elif defined(SDA_PIN)
+  #define beginWire() HAL_Wire.begin(SDA_PIN, 22, HAL_WIRE_CLOCK);
+#elif defined(SCL_PIN)
+  #define beginWire() HAL_Wire.begin(21, SCL_PIN, HAL_WIRE_CLOCK);
+#else
+  #define beginWire() HAL_Wire.begin(21, 22, HAL_WIRE_CLOCK);
+#endif
+
 #define HAL_INIT() { \
   analogWriteResolution(ANALOG_WRITE_PWM_BITS); \
   SERIAL_BT_BEGIN(); \
+  beginWire(); \
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/src/HAL/HAL_ESP32.h
+++ b/src/HAL/HAL_ESP32.h
@@ -51,13 +51,13 @@
 #endif
 
 #if (defined(SDA_PIN) && defined(SCL_PIN))
-  #define beginWire() HAL_Wire.begin(SDA_PIN, SCL_PIN, HAL_WIRE_CLOCK);
+#define beginWire() HAL_Wire.begin(SDA_PIN, SCL_PIN, HAL_WIRE_CLOCK);
 #elif defined(SDA_PIN)
-  #define beginWire() HAL_Wire.begin(SDA_PIN, 22, HAL_WIRE_CLOCK);
+#define beginWire() HAL_Wire.begin(SDA_PIN, 22, HAL_WIRE_CLOCK);
 #elif defined(SCL_PIN)
-  #define beginWire() HAL_Wire.begin(21, SCL_PIN, HAL_WIRE_CLOCK);
+#define beginWire() HAL_Wire.begin(21, SCL_PIN, HAL_WIRE_CLOCK);
 #else
-  #define beginWire() HAL_Wire.begin(21, 22, HAL_WIRE_CLOCK);
+#define beginWire() HAL_Wire.begin(21, 22, HAL_WIRE_CLOCK);
 #endif
 
 #define HAL_INIT() { \

--- a/src/lib/Constants.h
+++ b/src/lib/Constants.h
@@ -43,7 +43,8 @@
 #define TMC2226S                    11     // allows M0,M1    bit patterens for 8x,16x,32x,64x (M2 sets spreadCycle/stealthChop, uses 256x intpol)
 #define TMC2226U                    12     // uses TMC protocol UART comms  for 1x,2x...,256x  (UART sets spreadCycle/stealthChop etc. no mode switching)
 #define TMC5160                     13     // uses TMC protocol SPI comms   for 1x,2x...,256x  (SPI sets spreadCycle/stealthChop etc.)
-#define DRIVER_LAST                 13
+#define GENERIC2_STEPDIR_SERVO		14     // generic driver for servo motors using external step/dir control. for 1x,2x,4x,8x,16x,32x,64x,128x,256x (single pin mode switching)
+#define DRIVER_LAST                 14
 
 // driver (step/dir) decay mode
 #define DRIVER_DECAY_MODE_FIRST     1

--- a/src/lib/axis/motor/stepDir/StepDir.cpp
+++ b/src/lib/axis/motor/stepDir/StepDir.cpp
@@ -100,7 +100,7 @@ bool StepDirMotor::init() {
   }
 
   // init default driver direction pin for output
-  pinMode(Pins->dir, OUTPUT);
+  pinModeEx(Pins->dir, OUTPUT);
 
   // init default driver step state (clear)
   #ifndef DRIVER_STEP_DEFAULTS

--- a/src/lib/axis/motor/stepDir/StepDirDrivers.cpp
+++ b/src/lib/axis/motor/stepDir/StepDirDrivers.cpp
@@ -20,7 +20,8 @@ const static int8_t steps[DRIVER_MODEL_COUNT][9] =
  {OFF,  1,  2,  0,  3,OFF,OFF,OFF,OFF},   // TMC2208S
  {OFF,OFF,OFF,  0,  3,  1,  2,OFF,OFF},   // TMC2209S/TMC2226S
  {  8,  7,  6,  5,  4,  3,  2,  1,  0},   // TMC2209U/TMC2226U
- {  8,  7,  6,  5,  4,  3,  2,  1,  0}    // TMC5160
+ {  8,  7,  6,  5,  4,  3,  2,  1,  0},    // TMC5160
+ {  0,  1,  1,  1,  1,  1,  1,  1,  1},   // GENERIC2 - STEPDIR_SERVO
 };
 
 const static int32_t DriverPulseWidth[DRIVER_MODEL_COUNT] =
@@ -38,7 +39,8 @@ const static int32_t DriverPulseWidth[DRIVER_MODEL_COUNT] =
   103,   // TMC2208S
   103,   // TMC2209S/TMC2226S
   103,   // TMC2209U/TCM2226U
-  103    // TMC5160
+  103,    // TMC5160
+  1000,   // GENERIC2 - STEPDIR_SERVO. Enough for 500 KHz stepping
 };
 
 #if DEBUG != OFF
@@ -56,7 +58,8 @@ const static int32_t DriverPulseWidth[DRIVER_MODEL_COUNT] =
     "TMC2208 legacy",
     "TMC2209 legacy",
     "TMC2209/TMC2226 UART",
-    "TMC5160 SPI"
+    "TMC5160 SPI",
+    "GENERIC2-STEPDIR_SERVO"
   };
 #endif
 

--- a/src/lib/axis/motor/stepDir/StepDirDrivers.h
+++ b/src/lib/axis/motor/stepDir/StepDirDrivers.h
@@ -8,7 +8,7 @@
 #ifdef STEP_DIR_MOTOR_PRESENT
 
 // the various microsteps for different driver models, with the bit modes for each
-#define DRIVER_MODEL_COUNT 14
+#define DRIVER_MODEL_COUNT 15
 
 #include "../Drivers.h"
 #include "TmcDrivers.h"

--- a/src/lib/sound/Sound.cpp
+++ b/src/lib/sound/Sound.cpp
@@ -9,23 +9,25 @@
 
 #if STATUS_BUZZER == ON
   uint8_t _buzzerHandle = 0;
+  int16_t statusBuzzerPin = STATUS_BUZZER_PIN;
   void buzzerOff() {
-    digitalWriteEx(STATUS_BUZZER_PIN, !STATUS_BUZZER_ON_STATE);
+    digitalWriteEx(statusBuzzerPin, !STATUS_BUZZER_ON_STATE);
     tasks.setDurationComplete(_buzzerHandle);
   }
 #endif
 
 Sound::Sound() {
   #if STATUS_BUZZER == ON
-    pinModeEx(STATUS_BUZZER_PIN, OUTPUT);
-    digitalWriteEx(STATUS_BUZZER_PIN, !STATUS_BUZZER_ON_STATE);
+    statusBuzzerPin = STATUS_BUZZER_PIN;
+    pinModeEx(statusBuzzerPin, OUTPUT);
+    digitalWriteEx(statusBuzzerPin, !STATUS_BUZZER_ON_STATE);
   #endif
 }
 
 void Sound::alert() {
   if (enabled) {
     #if STATUS_BUZZER == ON
-      digitalWriteEx(STATUS_BUZZER_PIN, STATUS_BUZZER_ON_STATE);
+      digitalWriteEx(statusBuzzerPin, STATUS_BUZZER_ON_STATE);
       if (_buzzerHandle) tasks.remove(_buzzerHandle);
       _buzzerHandle = tasks.add(1000, 0, false, 6, buzzerOff);
     #endif
@@ -38,7 +40,7 @@ void Sound::alert() {
 void Sound::beep() {
   if (enabled) {
     #if STATUS_BUZZER == ON
-      digitalWriteEx(STATUS_BUZZER_PIN, STATUS_BUZZER_ON_STATE);
+      digitalWriteEx(statusBuzzerPin, STATUS_BUZZER_ON_STATE);
       if (_buzzerHandle) tasks.remove(_buzzerHandle);
       _buzzerHandle = tasks.add(250, 0, false, 6, buzzerOff);
     #endif
@@ -51,7 +53,7 @@ void Sound::beep() {
 void Sound::click() {
   if (enabled) {
     #if STATUS_BUZZER == ON
-      digitalWriteEx(STATUS_BUZZER_PIN, STATUS_BUZZER_ON_STATE);
+      digitalWriteEx(statusBuzzerPin, STATUS_BUZZER_ON_STATE);
       if (_buzzerHandle) tasks.remove(_buzzerHandle);
       _buzzerHandle = tasks.add(50, 0, false, 6, buzzerOff);
     #endif

--- a/src/lib/sound/Sound.h
+++ b/src/lib/sound/Sound.h
@@ -15,6 +15,7 @@ class Sound {
 
     bool enabled = STATUS_BUZZER_DEFAULT == ON; 
   private:
+    int16_t statusBuzzerPin = 0;
 };
 
 #endif

--- a/src/pinmaps/Models.h
+++ b/src/pinmaps/Models.h
@@ -43,6 +43,10 @@
   #define PINMAP_STR "MaxESP v4"
   #include "Pins.MaxESP4.h"
 #endif
+#if PINMAP == MaxESP_RCX400
+#define PINMAP_STR "MaxESP RCX 400 version"
+#include "Pins.MaxESP_RCX400.h"
+#endif
 #if PINMAP == STM32Blue
   #define PINMAP_STR "STM32 Bluepill"
   #include "Pins.STM32B.h"

--- a/src/pinmaps/Pins.MaxESP3.h
+++ b/src/pinmaps/Pins.MaxESP3.h
@@ -30,6 +30,10 @@
   #define SERIAL_TMC_NO_RX                       // Recieving data doesn't work with software serial
 #endif
 
+//SDA/SCL pins. 21/22 are the default values
+#define SDA_PIN              21
+#define SCL_PIN              22
+
 // Hint that the direction pins are shared
 #define SHARED_DIRECTION_PINS
 

--- a/src/pinmaps/Pins.MaxESP_RCX400.h
+++ b/src/pinmaps/Pins.MaxESP_RCX400.h
@@ -1,0 +1,160 @@
+#pragma once
+// -------------------------------------------------------------------------------------------------
+// Pin map for OnStep MaxESP Version 3.x (ESP32S)
+#pragma once
+
+#if defined(ESP32)
+
+// Serial ports (see Pins.defaults.h for SERIAL_A)
+// Serial0: RX Pin GPIO3, TX Pin GPIO1 (to USB serial adapter)
+// Serial1: RX1 Pin GPIO10, TX1 Pin GPIO9 (on SPI Flash pins, must be moved to be used)
+// Serial2: RX2 Pin GPIO16, TX2 Pin GPIO17
+
+#if SERIAL_B_BAUD_DEFAULT != OFF
+#define SERIAL_B              Serial2
+#endif
+#if SERIAL_C_BAUD_DEFAULT != OFF
+#error "Configuration (Config.h): SerialC isn't supported, disable this option."
+#endif
+
+#ifdef TMC2209_USE_HARDWARE_SERIAL
+  // Use the following settings for any TMC2209 that may be present
+#define SERIAL_TMC            Serial1          // Use a single hardware serial port to up to four drivers
+#define SERIAL_TMC_BAUD       460800           // Baud rate
+#define SERIAL_TMC_TX         23               // Transmit data
+#define SERIAL_TMC_RX         39               // Recieving data
+#define SERIAL_TMC_HARDCODED                   // Use hard-coded MS1/MS2 addresses for all drivers, sets M0/M1 to high
+#else
+  // Use the following settings for any TMC2209 that may be present
+#define SERIAL_TMC            SoftSerial       // Use software serial with RX on M2 and TX on M3 of axis
+#define SERIAL_TMC_BAUD       115200           // Baud rate
+#define SERIAL_TMC_NO_RX                       // Recieving data doesn't work with software serial
+#endif
+
+// Hint that the direction pins are shared
+#define SHARED_DIRECTION_PINS
+
+//Alternative SDA/SCL, if needed
+#define SDA_PIN              32
+#define SCL_PIN              25
+
+//Serial B
+#define SERIAL_B_RX          39
+#define SERIAL_B_TX          18
+
+// The multi-purpose pins (Aux3..Aux8 can be analog pwm/dac if supported)
+#define AUX2_PIN                4                // ESP8266 RST control, or MISO for Axis1&2, or Axis4 EN support
+#define AUX3_PIN                32               // Home SW for Axis1, or I2C SDA
+#define AUX4_PIN                25               // Home SW for Axis2, or I2C SCL
+
+#define AUX7_PIN                04               // Limit SW, PPS, etc.
+#define AUX8_PIN                27               // 1-Wire, Status LED, Status2 LED, Reticle LED, Tone, etc.
+#define AUX9_PIN                25               
+
+// Misc. pins
+#ifndef ONE_WIRE_PIN
+#define ONE_WIRE_PIN          AUX9_PIN         // Default Pin for OneWire bus
+#endif
+#define ADDON_GPIO0_PIN         17               // ESP8266 GPIO0 (Dir2) - Axis 2 DIR
+#ifndef ADDON_RESET_PIN
+#define ADDON_RESET_PIN       AUX2_PIN         // ESP8266 RST
+#endif
+
+// The PEC index sense is a logic level input, resets the PEC index on rising edge then waits for 60 seconds before allowing another reset
+#ifndef PEC_SENSE_PIN
+#define PEC_SENSE_PIN         36               // [input only 36] PEC Sense, analog (A0) or digital (GPIO36)
+#endif
+
+// The status LED is a two wire jumper with a 10k resistor in series to limit the current to the LED
+#ifndef STATUS_LED_PIN
+#define STATUS_LED_PIN        527         // Default LED Cathode (-)
+#endif
+#define MOUNT_STATUS_LED_PIN    528   // Default LED Cathode (-)
+#define STATUS_ROTATOR_LED_PIN  OFF   // Default LED Cathode (-)
+#define STATUS_FOCUSER_LED_PIN  525   // Default LED Cathode (-)
+#ifndef RETICLE_LED_PIN 
+#define RETICLE_LED_PIN       OFF   // Default LED Cathode (-)
+#endif
+
+// For a piezo buzzer
+#ifndef STATUS_BUZZER_PIN
+#define STATUS_BUZZER_PIN     526         // Tone
+#endif
+
+// The PPS pin is a 3.3V logic input, OnStep measures time between rising edges and adjusts the internal sidereal clock frequency
+#ifndef PPS_SENSE_PIN
+#define PPS_SENSE_PIN         AUX7_PIN         // PPS time source, GPS for example
+#endif
+
+// The limit switch sense is a logic level input normally pull high (2k resistor,) shorted to ground it stops gotos/tracking
+#ifndef LIMIT_SENSE_PIN
+#define LIMIT_SENSE_PIN       0
+#endif
+
+// Axis1 RA/Azm step/dir driver
+#define AXIS1_ENABLE_PIN        521               // [must be low at boot 12]
+#define AXIS1_M0_PIN            16               // SPI MOSI
+#define AXIS1_M1_PIN            OFF               // SPI SCK
+#define AXIS1_M2_PIN            OFF              // SPI CS (UART TX)
+#define AXIS1_M3_PIN            OFF         // SPI MISO (UART RX)
+#define AXIS1_STEP_PIN          23
+#define AXIS1_DIR_PIN           2               // [must be high at boot 0]
+#define AXIS1_DECAY_PIN         OFF
+#ifndef AXIS1_SENSE_HOME_PIN
+#define AXIS1_SENSE_HOME_PIN  OFF
+#endif
+
+// Axis2 Dec/Alt step/dir driver
+#define AXIS2_ENABLE_PIN        SHARED
+#define AXIS2_M0_PIN            523               // SPI MOSI
+#define AXIS2_M1_PIN            OFF               // SPI SCK
+#define AXIS2_M2_PIN            OFF                // SPI CS (UART TX)
+#define AXIS2_M3_PIN            OFF         // SPI MISO (UART RX)
+#define AXIS2_STEP_PIN          21
+#define AXIS2_DIR_PIN           522
+#define AXIS2_DECAY_PIN         OFF
+#ifndef AXIS2_SENSE_HOME_PIN
+#define AXIS2_SENSE_HOME_PIN  OFF
+#endif
+
+// For rotator stepper driver
+#define AXIS3_ENABLE_PIN        OFF              // No enable pin control (always enabled)
+#define AXIS3_M0_PIN            OFF              // SPI MOSI
+#define AXIS3_M1_PIN            OFF              // SPI SCK
+#define AXIS3_M2_PIN            OFF              // SPI CS (UART TX)
+#define AXIS3_M3_PIN            OFF              // SPI MISO (UART RX)
+#define AXIS3_STEP_PIN          2                // [must be low at boot 2]
+#define AXIS3_DIR_PIN           15
+
+// For focuser1 stepper driver
+#ifndef TMC2209_USE_HARDWARE_SERIAL
+#define AXIS4_ENABLE_PIN      ON
+#else
+#define AXIS4_ENABLE_PIN      AUX2_PIN         // Enable pin on AUX2_PIN but can be turned OFF during validation
+#endif
+#define AXIS4_M0_PIN            OFF              // SPI MOSI
+#define AXIS4_M1_PIN            OFF              // SPI SCK
+#define AXIS4_M2_PIN            OFF              // SPI CS (UART TX)
+#define AXIS4_M3_PIN            OFF              // SPI MISO (UART RX)
+#define AXIS4_STEP_PIN          35
+#define AXIS4_DIR_PIN           13
+
+// For focuser2 stepper driver
+#define AXIS5_ENABLE_PIN        OFF              // No enable pin control (always enabled)
+#define AXIS5_M0_PIN            OFF              // SPI MOSI
+#define AXIS5_M1_PIN            OFF              // SPI SCK
+#define AXIS5_M2_PIN            OFF              // SPI CS (UART TX)
+#define AXIS5_M3_PIN            OFF              // SPI MISO (UART RX)
+#define AXIS5_STEP_PIN          2
+#define AXIS5_DIR_PIN           15
+
+// ST4 interface
+#define ST4_RA_W_PIN            35               // [input only 34] ST4 RA- West
+#define ST4_DEC_S_PIN           9               // ST4 DE- South
+#define ST4_DEC_N_PIN           33               // ST4 DE+ North
+#define ST4_RA_E_PIN            34               // [input only 35] ST4 RA+ East
+
+#else
+#error "Wrong processor for this configuration!"
+
+#endif

--- a/src/telescope/addonFlasher/AddonFlasher.cpp
+++ b/src/telescope/addonFlasher/AddonFlasher.cpp
@@ -14,9 +14,12 @@
   #endif
 
   void AddonFlasher::init() {
-    VF("MSG: AddonFlasher, init gpio0="); V(ADDON_GPIO0_PIN); VF(", reset="); VL(ADDON_RESET_PIN);
-    pinMode(ADDON_GPIO0_PIN, OUTPUT);
-    pinMode(ADDON_RESET_PIN, OUTPUT);
+    addonGPIOPin = ADDON_GPIO0_PIN;
+    addonResetPin = ADDON_RESET_PIN;
+    VF("MSG: AddonFlasher, init gpio0="); V(addonGPIOPin); VF(", reset="); VL(addonResetPin);
+    pinModeEx(addonGPIOPin, OUTPUT);
+    pinModeEx(addonResetPin, OUTPUT);
+
 
     run();
 
@@ -67,7 +70,7 @@
     VLF("MSG: AddonFlasher, setting addon run mode");
 
     // enter run mode
-    digitalWrite(ADDON_GPIO0_PIN, HIGH);
+    digitalWriteEx(addonGPIOPin, HIGH);
     reset();
 
     if (setSerial) {
@@ -103,16 +106,16 @@
     tasks.yield(1000);
 
     // enter program mode
-    digitalWrite(ADDON_GPIO0_PIN, LOW);
+    digitalWriteEx(addonGPIOPin, LOW);
     reset();
   }
 
   void AddonFlasher::reset() {
     // reset LOW (active) HIGH (inactive)
     tasks.yield(20);
-    digitalWrite(ADDON_RESET_PIN, LOW);
+    digitalWriteEx(addonResetPin, LOW);
     tasks.yield(20);
-    digitalWrite(ADDON_RESET_PIN, HIGH);
+    digitalWriteEx(addonResetPin, HIGH);
     tasks.yield(20);
   }
 

--- a/src/telescope/addonFlasher/AddonFlasher.h
+++ b/src/telescope/addonFlasher/AddonFlasher.h
@@ -23,6 +23,8 @@
       // monitors for flash button press
       void poll();
     private:
+      uint16_t addonGPIOPin = 0;
+      uint16_t addonResetPin = 0;
   };
 
   extern AddonFlasher addonFlasher;

--- a/src/telescope/focuser/Focuser.cpp
+++ b/src/telescope/focuser/Focuser.cpp
@@ -13,7 +13,7 @@
 typedef struct FocuserConfiguration {
   bool present;
   uint16_t slewRateDesired;
-  uint8_t  slewRateMinimum;
+  uint16_t  slewRateMinimum;
   uint8_t  accelerationTime;
   uint8_t  rapidStopTime;
   bool powerDown;

--- a/src/telescope/mount/status/Status.cpp
+++ b/src/telescope/mount/status/Status.cpp
@@ -11,72 +11,79 @@
 #if STATUS_MOUNT_LED != OFF && MOUNT_STATUS_LED_PIN != OFF
   bool ledOn = false;
   bool ledOff = false;
+  int16_t statusLedPin = STATUS_LED_PIN;
+  int16_t mountStatusLedPin = MOUNT_STATUS_LED_PIN;
   void flash() {
-    if (ledOff) { digitalWriteEx(STATUS_LED_PIN, !STATUS_LED_ON_STATE); return; }
-    if (ledOn) { digitalWriteEx(STATUS_LED_PIN, STATUS_LED_ON_STATE); return; }
+    if (ledOff) { digitalWriteEx(statusLedPin, !STATUS_LED_ON_STATE); return; }
+    if (ledOn) { digitalWriteEx(statusLedPin, STATUS_LED_ON_STATE); return; }
     static uint8_t cycle = 0;
     if ((cycle++)%2 == 0) {
-      digitalWriteEx(MOUNT_STATUS_LED_PIN, !STATUS_MOUNT_LED_ON_STATE);
+      digitalWriteEx(mountStatusLedPin, !STATUS_MOUNT_LED_ON_STATE);
     } else {
-      digitalWriteEx(MOUNT_STATUS_LED_PIN, STATUS_MOUNT_LED_ON_STATE);
+      digitalWriteEx(mountStatusLedPin, STATUS_MOUNT_LED_ON_STATE);
     }
-  }
+}
 #endif
 
 void generalWrapper() { status.general(); }
 
 // get mount status ready
 void Status::init() {
-  if (!nv.hasValidKey()) {
-    VLF("MSG: Mount, status writing defaults to NV");
-    nv.write(NV_MOUNT_STATUS_BASE, (uint8_t)sound.enabled);
-  }
+    if (!nv.hasValidKey()) {
+        VLF("MSG: Mount, status writing defaults to NV");
+        nv.write(NV_MOUNT_STATUS_BASE, (uint8_t)sound.enabled);
+    }
 
-  #if STATUS_BUZZER_MEMORY == ON
+#if STATUS_BUZZER_MEMORY == ON
     sound.enabled = nv.read(NV_MOUNT_STATUS_BASE);
-  #endif
+#endif
 
   #if PARK_STATUS != OFF && PARK_STATUS_PIN != OFF
-    pinModeEx(PARK_STATUS_PIN, OUTPUT);
+    mountStatusLedPin = MOUNT_STATUS_LED_PIN;
+    parkStatusPin = PARK_STATUS_PIN;
+    pinModeEx(parkStatusPin, OUTPUT);
   #endif
 }
 
 // late init once tracking is enabled
 void Status::ready() {
-  #if STATUS_LED == ON
+#if STATUS_LED == ON
     // if anything else is using the status LED, disable it
     if (STATUS_MOUNT_LED != OFF && MOUNT_STATUS_LED_PIN == STATUS_LED_PIN) tasks.remove(tasks.getHandleByName("StaLed"));
-  #endif
+#endif
 
-  #if STATUS_MOUNT_LED != OFF && MOUNT_STATUS_LED_PIN != OFF
+#if STATUS_MOUNT_LED != OFF && MOUNT_STATUS_LED_PIN != OFF
     if (!tasks.getHandleByName("mntLed")) {
-      pinModeEx(MOUNT_STATUS_LED_PIN, OUTPUT);
+      pinModeEx(mountStatusLedPin, OUTPUT);
       VF("MSG: Mount, status start LED task (variable rate priority 4)... ");
       statusTaskHandle = tasks.add(0, 0, true, 4, flash, "mntLed");
       if (statusTaskHandle) { VLF("success"); } else { VLF("FAILED!"); }
     }
-  #endif
+#endif
 
-  VF("MSG: Mount, status start general status task (1s rate priority 4)... ");
-  statusTaskHandle = tasks.add(1000, 0, true, 4, generalWrapper, "genSta");
-  if (statusTaskHandle) { VLF("success"); } else { VLF("FAILED!"); }
+    VF("MSG: Mount, status start general status task (1s rate priority 4)... ");
+    statusTaskHandle = tasks.add(1000, 0, true, 4, generalWrapper, "genSta");
+    if (statusTaskHandle) { VLF("success"); }
+    else { VLF("FAILED!"); }
 }
 
 // mount status LED flash rate (in ms)
 void Status::flashRate(int period) {
-  #if STATUS_MOUNT_LED != OFF && MOUNT_STATUS_LED_PIN != OFF
-    if (period == 0) { period = 500; ledOff = true; } else ledOff = false;
-    if (period == 1) { period = 500; ledOn = true; } else ledOn = false;
-    tasks.setPeriod(statusTaskHandle, period/2UL);
-  #else
+#if STATUS_MOUNT_LED != OFF && MOUNT_STATUS_LED_PIN != OFF
+    if (period == 0) { period = 500; ledOff = true; }
+    else ledOff = false;
+    if (period == 1) { period = 500; ledOn = true; }
+    else ledOn = false;
+    tasks.setPeriod(statusTaskHandle, period / 2UL);
+#else
     period = period;
-  #endif
+#endif
 }
 
 // mount general status
 void Status::general() {
   #if PARK_STATUS != OFF && PARK_STATUS_PIN != OFF
-    digitalWriteEx(PARK_STATUS_PIN, (park.state == PS_PARKED) ? PARK_STATUS : !PARK_STATUS)
+    digitalWriteEx(parkStatusPin, (park.state == PS_PARKED) ? PARK_STATUS : !PARK_STATUS)
   #endif
 }
 

--- a/src/telescope/mount/status/Status.h
+++ b/src/telescope/mount/status/Status.h
@@ -13,14 +13,14 @@
 #define SF_SLEWING 1
 
 class Status {
-  public:
+public:
     // get mount status ready
     void init();
 
     // late init once tracking is enabled
     void ready();
 
-    bool command(char *reply, char *command, char *parameter, bool *supressFrame, bool *numericReply, CommandError *commandError);
+    bool command(char* reply, char* command, char* parameter, bool* supressFrame, bool* numericReply, CommandError* commandError);
 
     // mount status LED flash rate (in ms)
     void flashRate(int period);
@@ -29,8 +29,10 @@ class Status {
 
     Sound sound;
 
-  private:
+private:
     uint8_t statusTaskHandle = 0;
+    uint16_t mountStatusLedPin = 0;
+    uint16_t parkStatusPin = 0;
 };
 
 extern Status status;


### PR DESCRIPTION
it is now possible to specify custom SDA SCL pins in the pin maps for ESP32.
We tested that you simply need to call the wire.begin() once to set the pins, and the selection will be maintained in subsequent init call of the various sensors using I2C.

Example is added on how to specify the pins on the MaxESP3 pin map