### PR TITLE
added custom SDA SCL pins for ESP32 I2C

### DIFF
--- a/src/HAL/HAL_ESP32.h
+++ b/src/HAL/HAL_ESP32.h
@@ -50,9 +50,20 @@
   #error "Configuration (Config.h): SERIAL_BT_MODE and SERIAL_IP_MODE can't be enabled at the same time, disable one or both options."
 #endif
 
+#if (defined(SDA_PIN) && defined(SCL_PIN))
+  #define beginWire() HAL_Wire.begin(SDA_PIN, SCL_PIN, HAL_WIRE_CLOCK);
+#elif defined(SDA_PIN)
+  #define beginWire() HAL_Wire.begin(SDA_PIN, 22, HAL_WIRE_CLOCK);
+#elif defined(SCL_PIN)
+  #define beginWire() HAL_Wire.begin(21, SCL_PIN, HAL_WIRE_CLOCK);
+#else
+  #define beginWire() HAL_Wire.begin(21, 22, HAL_WIRE_CLOCK);
+#endif
+
 #define HAL_INIT() { \
   analogWriteResolution(ANALOG_WRITE_PWM_BITS); \
   SERIAL_BT_BEGIN(); \
+  beginWire(); \
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/src/HAL/HAL_ESP32.h
+++ b/src/HAL/HAL_ESP32.h
@@ -50,20 +50,10 @@
   #error "Configuration (Config.h): SERIAL_BT_MODE and SERIAL_IP_MODE can't be enabled at the same time, disable one or both options."
 #endif
 
-#if (defined(SDA_PIN) && defined(SCL_PIN))
-  #define beginWire() HAL_Wire.begin(SDA_PIN, SCL_PIN, HAL_WIRE_CLOCK);
-#elif defined(SDA_PIN)
-  #define beginWire() HAL_Wire.begin(SDA_PIN, 22, HAL_WIRE_CLOCK);
-#elif defined(SCL_PIN)
-  #define beginWire() HAL_Wire.begin(21, SCL_PIN, HAL_WIRE_CLOCK);
-#else
-  #define beginWire() HAL_Wire.begin(21, 22, HAL_WIRE_CLOCK);
-#endif
-
 #define HAL_INIT() { \
   analogWriteResolution(ANALOG_WRITE_PWM_BITS); \
   SERIAL_BT_BEGIN(); \
-  beginWire(); \
+  HAL_Wire.begin(SDA_PIN, SCL_PIN, HAL_WIRE_CLOCK); \
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/src/pinmaps/Pins.MaxESP3.h
+++ b/src/pinmaps/Pins.MaxESP3.h
@@ -30,6 +30,10 @@
   #define SERIAL_TMC_NO_RX                       // Recieving data doesn't work with software serial
 #endif
 
+//SDA/SCL pins. 21/22 are the default values
+#define SDA_PIN              21
+#define SCL_PIN              22
+
 // Hint that the direction pins are shared
 #define SHARED_DIRECTION_PINS
 

--- a/src/pinmaps/Pins.defaults.h
+++ b/src/pinmaps/Pins.defaults.h
@@ -21,6 +21,14 @@
 #define SERIAL_TMC_AXIS5_REMAP                   // Identify Focuser2 (Axis5) as Axis3
 */
 
+#ifndef SDA_PIN
+#define SDA_PIN                    21
+#endif
+
+#ifndef SCL_PIN
+#define SCL_PIN                    22
+#endif
+
 #ifndef AUX0_PIN
 #define AUX0_PIN                    OFF
 #endif


### PR DESCRIPTION
it is now possible to specify custom SDA SCL pins in the pin maps for ESP32.
We tested that you simply need to call the wire.begin() once to set the pins, and the selection will be maintained in subsequent init call of the various sensors using I2C.

Example is added on how to specify the pins on the MaxESP3 pin map