### PR TITLE
Step dir servo

### DIFF
--- a/src/lib/Constants.h
+++ b/src/lib/Constants.h
@@ -43,7 +43,7 @@
 #define TMC2226S                    11     // allows M0,M1    bit patterens for 8x,16x,32x,64x (M2 sets spreadCycle/stealthChop, uses 256x intpol)
 #define TMC2226U                    12     // uses TMC protocol UART comms  for 1x,2x...,256x  (UART sets spreadCycle/stealthChop etc. no mode switching)
 #define TMC5160                     13     // uses TMC protocol SPI comms   for 1x,2x...,256x  (SPI sets spreadCycle/stealthChop etc.)
-#define GENERIC2_STEPDIR_SERVO		14     // generic driver for servo motors using external step/dir control. for 1x,2x,4x,8x,16x,32x,64x,128x,256x (single pin mode switching)
+#define GENERIC2_STEPDIR_SERVO      14     // generic driver for servo motors using external step/dir control. for 1x,2x,4x,8x,16x,32x,64x,128x,256x (single pin mode switching)
 #define DRIVER_LAST                 14
 
 // driver (step/dir) decay mode

--- a/src/lib/Constants.h
+++ b/src/lib/Constants.h
@@ -43,7 +43,8 @@
 #define TMC2226S                    11     // allows M0,M1    bit patterens for 8x,16x,32x,64x (M2 sets spreadCycle/stealthChop, uses 256x intpol)
 #define TMC2226U                    12     // uses TMC protocol UART comms  for 1x,2x...,256x  (UART sets spreadCycle/stealthChop etc. no mode switching)
 #define TMC5160                     13     // uses TMC protocol SPI comms   for 1x,2x...,256x  (SPI sets spreadCycle/stealthChop etc.)
-#define DRIVER_LAST                 13
+#define GENERIC2_STEPDIR_SERVO		14     // generic driver for servo motors using external step/dir control. for 1x,2x,4x,8x,16x,32x,64x,128x,256x (single pin mode switching)
+#define DRIVER_LAST                 14
 
 // driver (step/dir) decay mode
 #define DRIVER_DECAY_MODE_FIRST     1

--- a/src/lib/axis/motor/stepDir/StepDirDrivers.cpp
+++ b/src/lib/axis/motor/stepDir/StepDirDrivers.cpp
@@ -20,7 +20,7 @@ const static int8_t steps[DRIVER_MODEL_COUNT][9] =
  {OFF,  1,  2,  0,  3,OFF,OFF,OFF,OFF},   // TMC2208S
  {OFF,OFF,OFF,  0,  3,  1,  2,OFF,OFF},   // TMC2209S/TMC2226S
  {  8,  7,  6,  5,  4,  3,  2,  1,  0},   // TMC2209U/TMC2226U
- {  8,  7,  6,  5,  4,  3,  2,  1,  0},    // TMC5160
+ {  8,  7,  6,  5,  4,  3,  2,  1,  0},   // TMC5160
  {  0,  1,  1,  1,  1,  1,  1,  1,  1},   // GENERIC2 - STEPDIR_SERVO
 };
 
@@ -39,8 +39,8 @@ const static int32_t DriverPulseWidth[DRIVER_MODEL_COUNT] =
   103,   // TMC2208S
   103,   // TMC2209S/TMC2226S
   103,   // TMC2209U/TCM2226U
-  103,    // TMC5160
-  1000,   // GENERIC2 - STEPDIR_SERVO. Enough for 500 KHz stepping
+  103,   // TMC5160
+  1000,  // GENERIC2 - STEPDIR_SERVO. Enough for 500 KHz stepping
 };
 
 #if DEBUG != OFF

--- a/src/lib/axis/motor/stepDir/StepDirDrivers.cpp
+++ b/src/lib/axis/motor/stepDir/StepDirDrivers.cpp
@@ -20,7 +20,8 @@ const static int8_t steps[DRIVER_MODEL_COUNT][9] =
  {OFF,  1,  2,  0,  3,OFF,OFF,OFF,OFF},   // TMC2208S
  {OFF,OFF,OFF,  0,  3,  1,  2,OFF,OFF},   // TMC2209S/TMC2226S
  {  8,  7,  6,  5,  4,  3,  2,  1,  0},   // TMC2209U/TMC2226U
- {  8,  7,  6,  5,  4,  3,  2,  1,  0}    // TMC5160
+ {  8,  7,  6,  5,  4,  3,  2,  1,  0},    // TMC5160
+ {  0,  1,  1,  1,  1,  1,  1,  1,  1},   // GENERIC2 - STEPDIR_SERVO
 };
 
 const static int32_t DriverPulseWidth[DRIVER_MODEL_COUNT] =
@@ -38,7 +39,8 @@ const static int32_t DriverPulseWidth[DRIVER_MODEL_COUNT] =
   103,   // TMC2208S
   103,   // TMC2209S/TMC2226S
   103,   // TMC2209U/TCM2226U
-  103    // TMC5160
+  103,    // TMC5160
+  1000,   // GENERIC2 - STEPDIR_SERVO. Enough for 500 KHz stepping
 };
 
 #if DEBUG != OFF
@@ -56,7 +58,8 @@ const static int32_t DriverPulseWidth[DRIVER_MODEL_COUNT] =
     "TMC2208 legacy",
     "TMC2209 legacy",
     "TMC2209/TMC2226 UART",
-    "TMC5160 SPI"
+    "TMC5160 SPI",
+    "GENERIC2-STEPDIR_SERVO"
   };
 #endif
 

--- a/src/lib/axis/motor/stepDir/StepDirDrivers.h
+++ b/src/lib/axis/motor/stepDir/StepDirDrivers.h
@@ -8,7 +8,7 @@
 #ifdef STEP_DIR_MOTOR_PRESENT
 
 // the various microsteps for different driver models, with the bit modes for each
-#define DRIVER_MODEL_COUNT 14
+#define DRIVER_MODEL_COUNT 15
 
 #include "../Drivers.h"
 #include "TmcDrivers.h"


### PR DESCRIPTION
The addition of the servo class in OnStepX is deeply appreciated and useful.
However, I am now using an external board to control a servo motor, using dir/step command.

I think some other people might want this functionality, to allow flexibility.
As such, I've re-added a generic motor controller, that uses DIR STEP commands, and can do mode switching using a single pin.

Of course, care must be taken to consider the slewing and goto micro-steps settings.
The original OnStep changed the logic of micro-stepping when slewing if a servo was selected, such that (for servo), you could use a larger microstepping value when slewing (compared to small movements), and obtain larger movements per step.

But I think leaving it as is should be ok...and then care must be taken by the person using this to correctly set microstep values.

