### PR TITLE
Multiple shared enable pins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
-
 .vscode/settings.json
 *.json
-*.json
-*.json
 src/plugins
+__vm/*
+*.vcxproj*
+.vs/*
+*.sln
+Debug/*
+Release/*

--- a/src/Config.defaults.h
+++ b/src/Config.defaults.h
@@ -146,6 +146,16 @@
 #define FileVersionConfig 5
 #endif
 
+//shared enables
+#ifndef SHARED_ENABLE_STATE
+#define SHARED_ENABLE_STATE           LOW                         // default state of shared ENable pin for motor power on
+#endif
+#ifndef SHARED2_ENABLE_STATE
+#define SHARED2_ENABLE_STATE          LOW                         // default state of shared ENable pin for motor power on
+#endif
+#ifndef SHARED3_ENABLE_STATE
+#define SHARED3_ENABLE_STATE          LOW                         // default state of shared ENable pin for motor power on
+#endif
 // -----------------------------------------------------------------------------------
 // mount settings
 

--- a/src/telescope/Telescope.cpp
+++ b/src/telescope/Telescope.cpp
@@ -78,8 +78,18 @@ void Telescope::init(const char *fwName, int fwMajor, int fwMinor, const char *f
 
   #ifdef SHARED_ENABLE_PIN
     pinModeEx(SHARED_ENABLE_PIN, OUTPUT);
-    digitalWriteEx(SHARED_ENABLE_PIN, HIGH);
+    digitalWriteEx(SHARED_ENABLE_PIN, !SHARED_ENABLE_STATE);
   #endif
+
+#ifdef SHARED_ENABLE_PIN2
+	pinModeEx(SHARED_ENABLE_PIN2, OUTPUT);
+	digitalWriteEx(SHARED_ENABLE_PIN2, !SHARED2_ENABLE_STATE);
+#endif
+
+#ifdef SHARED_ENABLE_PIN3
+	pinModeEx(SHARED_ENABLE_PIN3, OUTPUT);
+	digitalWriteEx(SHARED_ENABLE_PIN3, !SHARED3_ENABLE_STATE);
+#endif
 
   #ifdef MOUNT_PRESENT
     mount.init();
@@ -95,8 +105,16 @@ void Telescope::init(const char *fwName, int fwMajor, int fwMinor, const char *f
   #endif
 
   #ifdef SHARED_ENABLE_PIN
-    digitalWriteEx(SHARED_ENABLE_PIN, LOW);
+    digitalWriteEx(SHARED_ENABLE_PIN, SHARED_ENABLE_STATE);
   #endif
+
+#ifdef SHARED_ENABLE_PIN2
+	digitalWriteEx(SHARED_ENABLE_PIN2, SHARED2_ENABLE_STATE);
+#endif
+
+#ifdef SHARED_ENABLE_PIN3
+	digitalWriteEx(SHARED_ENABLE_PIN3, SHARED3_ENABLE_STATE);
+#endif
 
   #ifdef MOUNT_PRESENT
     mount.begin();


### PR DESCRIPTION
Added the possibility of having multiple shared enable pins, and setting the enable state in the configuration file.

This would be useful if, for example, you have a group of shared pin for the axis, and another for multiple focusers/collimation/rotator motors.