### PR TITLE
adjusted focuser files to allow a faster minimum rate

### DIFF
--- a/src/Validate.h
+++ b/src/Validate.h
@@ -531,8 +531,8 @@
   #error "Configuration (Config.h): Setting AXIS4_DRIVER_MODEL unknown, use OFF or a valid DRIVER (from Constants.h)"
 #endif
 
-#if AXIS4_SLEW_RATE_MINIMUM < 5 || AXIS4_SLEW_RATE_MINIMUM > 200
-  #error "Configuration (Config.h): Setting AXIS4_SLEW_RATE_MINIMUM out of range, use a value between 5 and 200"
+#if AXIS4_SLEW_RATE_MINIMUM < 5 || AXIS4_SLEW_RATE_MINIMUM > 600
+  #error "Configuration (Config.h): Setting AXIS4_SLEW_RATE_MINIMUM out of range, use a value between 5 and 600"
 #endif
 
 #if AXIS4_SLEW_RATE_DESIRED < 200 || AXIS4_SLEW_RATE_DESIRED > 5000

--- a/src/telescope/focuser/Focuser.cpp
+++ b/src/telescope/focuser/Focuser.cpp
@@ -14,7 +14,7 @@
 typedef struct FocuserConfiguration {
   bool present;
   uint16_t slewRateDesired;
-  uint8_t  slewRateMinimum;
+  uint16_t slewRateMinimum;
   float    accelerationTime;
   float    rapidStopTime;
   bool     powerDown;


### PR DESCRIPTION
I think it might make sense to allow a minimum slew rate as high as the desired slew rate.

You might not agree on this, but I though it was worth it to do a pull request anyway...