### PR TITLE
Fixed one bug in homing

### DIFF
--- a/src/telescope/mount/guide/Guide.cpp
+++ b/src/telescope/mount/guide/Guide.cpp
@@ -436,11 +436,12 @@ void Guide::poll() {
   // handle end of home guiding
   if ((state == GU_HOME_GUIDE || state == GU_HOME_GUIDE_ABORT) && !mount.isSlewing()) {
     #if AXIS2_TANGENT_ARM == OFF
+      GuideState oldState = state;
       state = GU_NONE;
       guideActionAxis1 = GA_NONE;
       guideActionAxis2 = GA_NONE;
       mountStatus.sound.alert();
-      if (state == GU_HOME_GUIDE) {
+      if (oldState == GU_HOME_GUIDE) {
         VLF("MSG: Guide, arrival at home detected");
         home.reset(home.isRequestWithReset);
       }


### PR DESCRIPTION
In the original code, once guiding to home is completed, the if(state == GU_HOME_GUIDE) can never be executed, as state was set to GU_NONE earlier.

Changed the code so state at the beginning of the function call is saved and used in the if condition instead.