### PR TITLE
add creality 1.1.4 (melzi) support

### DIFF
--- a/src/Constants.h
+++ b/src/Constants.h
@@ -32,7 +32,9 @@
 
 #define STM32Blue                   18     // Khalid and Dave's PCB for STM32 Blue pill (STM32F103CB and STM32F303CC)
 
-#define PINMAP_LAST                 18
+#define CrealityMelzi               19     // For Creality Melzi Boars
+
+#define PINMAP_LAST                 19
 
 // WEATHER sensors (temperature, pressure, and humidity)
 #define WEATHER_FIRST               1

--- a/src/HAL/HAL.h
+++ b/src/HAL/HAL.h
@@ -24,6 +24,10 @@
   #define MCU_STR "Mega1280"
   #include "HAL_Mega2560.h"
 
+#elif defined(__AVR_ATmega1284P__)
+  #define MCU_STR "Mega1284P"
+  #include "HAL_Mega1284P.h"
+  
 #elif defined(__AVR_ATmega2560__)
   #define MCU_STR "Mega2560"
   #include "HAL_Mega2560.h"

--- a/src/HAL/HAL_Mega1284P.h
+++ b/src/HAL/HAL_Mega1284P.h
@@ -1,0 +1,53 @@
+// Platform setup ------------------------------------------------------------------------------------
+#pragma once
+
+// This is for fast processors with hardware FP
+#define HAL_SLOW_PROCESSOR
+
+// 1/100 second sidereal timer
+#define HAL_FRACTIONAL_SEC 100.0F
+
+// Analog read and write
+#ifndef ANALOG_READ_RANGE
+  #define ANALOG_READ_RANGE 1023
+#endif
+#ifndef ANALOG_WRITE_RANGE
+  #define ANALOG_WRITE_RANGE 255
+#endif
+#ifndef ANALOG_WRITE_PWM_BITS
+  #define ANALOG_WRITE_PWM_BITS 8
+#endif
+
+// Lower limit (fastest) step rate in uS for this platform (in SQW mode) and width of step pulse
+#define HAL_MAXRATE_LOWER_LIMIT 76.8
+
+#define HAL_PULSE_WIDTH 0  // in ns, measured 1/18/22 (ESP32 v2.0.0)
+
+// New symbol for the default I2C port -------------------------------------------------------------
+#include <Wire.h>
+#define HAL_Wire Wire
+#define HAL_WIRE_CLOCK 100000
+
+// Non-volatile storage ----------------------------------------------------------------------------
+#if NV_DRIVER == NV_DEFAULT
+  #include "../lib/nv/NV_EEPROM.h"
+  #define HAL_NV_INIT() nv.init(2048, true, 0, false);
+#endif
+
+//--------------------------------------------------------------------------------------------------
+// General purpose initialize for HAL
+#define HAL_INIT() { ; }
+
+//--------------------------------------------------------------------------------------------------
+// Internal MCU temperature (in degrees C)
+#define HAL_TEMP() ( -999 )
+
+// MCU reset
+//#define HAL_RESET() ESP.restart()
+
+// a really short fixed delay (none needed)
+//#define HAL_DELAY_25NS()
+
+// stand-in for delayNanoseconds(), assumes 240MHz clock
+//#include "xtensa/core-macros.h"
+//#define delayNanoseconds(ns) { unsigned int c = xthal_get_ccount() + ns/4.166F; do {} while ((int)(xthal_get_ccount() - c) < 0); }

--- a/src/pinmaps/Models.h
+++ b/src/pinmaps/Models.h
@@ -71,6 +71,10 @@
   #define PINMAP_STR "MaxSTM v3"
   #include "Pins.MaxSTM.h"
 #endif
+#if PINMAP == CrealityMelzi
+  #define PINMAP_STR "Creality Melzi"
+  #include "Pins.CrealityMelzi.h"
+#endif
 
 // all unassigned pins OFF
 #include "../pinmaps/Pins.defaults.h"

--- a/src/pinmaps/Pins.CrealityMelzi.h
+++ b/src/pinmaps/Pins.CrealityMelzi.h
@@ -1,0 +1,121 @@
+// -------------------------------------------------------------------------------------------------
+// Null pin map, assigns OFF to all values not already assigned
+#pragma once
+
+#if defined(__AVR_ATmega1284P__)
+// --------------------------------------------------------------------------------------------------------
+// Serial, SPI, and I2C interface pins
+
+#if SERIAL_A_BAUD_DEFAULT != OFF
+  #define SERIAL_A              Serial
+#endif
+#if SERIAL_B_BAUD_DEFAULT != OFF
+  #define SERIAL_B              Serial1
+#endif
+
+#define SERIAL_B_RX                 10 // PD2 TX1 for ESP8266
+#define SERIAL_B_TX                 11 // PD3 RX1 for ESP8266
+
+#define I2C_SCL_PIN                 16 // PC0 SCL BTN_ENC
+#define I2C_SDA_PIN                 17 // PC1 SDA LCS_PINS_ENABLE
+
+// --------------------------------------------------------------------------------------------------------
+#define AUX0_PIN                    12 // PD4 HEATER_BED_PIN
+#define AUX1_PIN                    13 // PD5 HEATER_0_PIN
+#define AUX2_PIN                     4 // PB4 FAN_PIN
+#define AUX3_PIN                    24 // PA7 TEMP_0_PIN
+#define AUX4_PIN                    25 // PA6 TEMP_BED_PIN 
+
+#define ONE_WIRE_PIN                OFF
+#define ADDON_TRIGR_PIN             OFF
+#define ADDON_GPIO0_PIN             OFF
+#define ADDON_RESET_PIN             OFF
+#define PARK_SENSE_PIN              OFF
+#define PARK_SIGNAL_PIN             OFF
+#define PARK_STATUS_PIN             OFF
+#define PEC_SENSE_PIN               OFF
+#define STATUS_LED_PIN              OFF
+#define MOUNT_LED_PIN               OFF
+#define RETICLE_LED_PIN             OFF
+#define STATUS_BUZZER_PIN           OFF
+#define PPS_SENSE_PIN               OFF
+#define LIMIT_SENSE_PIN             OFF
+
+#define ST4_RA_W_PIN                OFF
+#define ST4_DEC_S_PIN               OFF
+#define ST4_DEC_N_PIN               OFF
+#define ST4_RA_E_PIN                OFF
+
+#define AXIS1_ENABLE_PIN            14
+#define AXIS1_M0_PIN                OFF
+#define AXIS1_M1_PIN                OFF
+#define AXIS1_M2_PIN                OFF
+#define AXIS1_M3_PIN                OFF
+#define AXIS1_STEP_PIN              15
+#define AXIS1_DIR_PIN               21
+#define AXIS1_SENSE_HOME_PIN        18
+
+#define AXIS2_ENABLE_PIN            SHARED
+#define AXIS2_M0_PIN                OFF
+#define AXIS2_M1_PIN                OFF
+#define AXIS2_M2_PIN                OFF
+#define AXIS2_M3_PIN                OFF
+#define AXIS2_STEP_PIN              22
+#define AXIS2_DIR_PIN               23
+#define AXIS2_SENSE_HOME_PIN        19
+
+#define AXIS3_ENABLE_PIN            SHARED
+#define AXIS3_M0_PIN                OFF
+#define AXIS3_M1_PIN                OFF
+#define AXIS3_M2_PIN                OFF
+#define AXIS3_M3_PIN                OFF
+#define AXIS3_STEP_PIN              OFF
+#define AXIS3_DIR_PIN               OFF
+#define AXIS3_SENSE_HOME_PIN        20
+
+#define AXIS4_ENABLE_PIN            SHARED
+#define AXIS4_M0_PIN                OFF
+#define AXIS4_M1_PIN                OFF
+#define AXIS4_M2_PIN                OFF
+#define AXIS4_M3_PIN                OFF
+#define AXIS4_STEP_PIN              OFF
+#define AXIS4_DIR_PIN               OFF
+
+#ifndef FOCUSER_TEMPERATURE_PIN
+#define FOCUSER_TEMPERATURE_PIN       OFF // analog pin
+#endif
+#ifndef FOCUSER_BUTTON_SENSE_IN_PIN
+#define FOCUSER_BUTTON_SENSE_IN_PIN   OFF
+#endif
+#ifndef FOCUSER_BUTTON_SENSE_OUT_PIN
+#define FOCUSER_BUTTON_SENSE_OUT_PIN  OFF
+#endif
+
+#ifndef FEATURE1_TEMPERATURE_PIN
+#define FEATURE1_TEMPERATURE_PIN      OFF // analog pin
+#endif
+#ifndef FEATURE2_TEMPERATURE_PIN
+#define FEATURE2_TEMPERATURE_PIN      OFF
+#endif
+#ifndef FEATURE3_TEMPERATURE_PIN
+#define FEATURE3_TEMPERATURE_PIN      OFF
+#endif
+#ifndef FEATURE4_TEMPERATURE_PIN
+#define FEATURE4_TEMPERATURE_PIN      OFF
+#endif
+#ifndef FEATURE5_TEMPERATURE_PIN
+#define FEATURE5_TEMPERATURE_PIN      OFF
+#endif
+#ifndef FEATURE6_TEMPERATURE_PIN
+#define FEATURE6_TEMPERATURE_PIN      OFF
+#endif
+#ifndef FEATURE7_TEMPERATURE_PIN
+#define FEATURE7_TEMPERATURE_PIN      OFF
+#endif
+#ifndef FEATURE8_TEMPERATURE_PIN
+#define FEATURE8_TEMPERATURE_PIN      OFF
+#endif
+
+#else
+  #error "Wrong processor for this configuration!"
+#endif


### PR DESCRIPTION
Add support for the 3D printer mainboard of en Ender-3 in the Hardware revision 1.1.4. It is based on the melzi design.