### PR TITLE
Bmx mode

### DIFF
--- a/src/libApp/weather/Weather.cpp
+++ b/src/libApp/weather/Weather.cpp
@@ -45,7 +45,7 @@ bool Weather::init() {
     success = false;
     #if WEATHER == BME280 || WEATHER == BME280_0x76
       if (bmx.begin(BME_ADDRESS, &HAL_Wire)) {
-        bmx.setSampling(Adafruit_BME280::MODE_FORCED, Adafruit_BME280::SAMPLING_X1, Adafruit_BME280::SAMPLING_X1, Adafruit_BME280::FILTER_OFF);
+        bmx.setSampling(Adafruit_BME280::MODE_FORCED, Adafruit_BME280::SAMPLING_X1, Adafruit_BME280::SAMPLING_X1, Adafruit_BME280::SAMPLING_X1, Adafruit_BME280::FILTER_OFF);
         weatherSensor = WS_BME280; success = true;
       } else { DF("WRN: Weather.init(), BME280 (I2C 0x"); if (DEBUG != OFF) SERIAL_DEBUG.print(BME_ADDRESS, HEX); DLF(") not found"); }
     #elif WEATHER == BMP280 || WEATHER == BMP280_0x76
@@ -55,7 +55,7 @@ bool Weather::init() {
       } else { DF("WRN: Weather.init(), BMP280 (I2C 0x"); if (DEBUG != OFF) SERIAL_DEBUG.print(BMP_ADDRESS, HEX); DLF(") not found"); }
     #elif WEATHER == BME280_SPI
       if (bmx.begin()) {
-        bmx.setSampling(Adafruit_BME280::MODE_FORCED, Adafruit_BME280::SAMPLING_X1, Adafruit_BME280::SAMPLING_X1, Adafruit_BME280::FILTER_OFF);
+        bmx.setSampling(Adafruit_BME280::MODE_FORCED, Adafruit_BME280::SAMPLING_X1, Adafruit_BME280::SAMPLING_X1, Adafruit_BME280::SAMPLING_X1, Adafruit_BME280::FILTER_OFF);
         weatherSensor = WS_BME280; success = true;
       } else { DLF("WRN: Weather.init(), BME280 (SPI) not found"); }
     #elif WEATHER == BMP280_SPI

--- a/src/libApp/weather/Weather.cpp
+++ b/src/libApp/weather/Weather.cpp
@@ -44,13 +44,25 @@ bool Weather::init() {
   #if WEATHER != OFF
     success = false;
     #if WEATHER == BME280 || WEATHER == BME280_0x76
-      if (bmx.begin(BME_ADDRESS, &HAL_Wire)) { weatherSensor = WS_BME280; success = true; } else { DF("WRN: Weather.init(), BME280 (I2C 0x"); if (DEBUG != OFF) SERIAL_DEBUG.print(BME_ADDRESS, HEX); DLF(") not found"); }
+      if (bmx.begin(BME_ADDRESS, &HAL_Wire)) {
+        bmx.setSampling(Adafruit_BME280::MODE_FORCED, Adafruit_BME280::SAMPLING_X1, Adafruit_BME280::SAMPLING_X1, Adafruit_BME280::FILTER_OFF);
+        weatherSensor = WS_BME280; success = true;
+      } else { DF("WRN: Weather.init(), BME280 (I2C 0x"); if (DEBUG != OFF) SERIAL_DEBUG.print(BME_ADDRESS, HEX); DLF(") not found"); }
     #elif WEATHER == BMP280 || WEATHER == BMP280_0x76
-      if (bmx.begin(BMP_ADDRESS)) { weatherSensor = WS_BMP280; success = true; } else { DF("WRN: Weather.init(), BMP280 (I2C 0x"); if (DEBUG != OFF) SERIAL_DEBUG.print(BMP_ADDRESS, HEX); DLF(") not found"); }
+      if (bmx.begin(BMP_ADDRESS)) {
+        bmx.setSampling(Adafruit_BMP280::MODE_FORCED, Adafruit_BMP280::SAMPLING_X1, Adafruit_BMP280::SAMPLING_X1, Adafruit_BMP280::FILTER_OFF);
+        weatherSensor = WS_BMP280; success = true;
+      } else { DF("WRN: Weather.init(), BMP280 (I2C 0x"); if (DEBUG != OFF) SERIAL_DEBUG.print(BMP_ADDRESS, HEX); DLF(") not found"); }
     #elif WEATHER == BME280_SPI
-      if (bmx.begin()) { weatherSensor = WS_BME280; success = true; } else { DLF("WRN: Weather.init(), BME280 (SPI) not found"); }
+      if (bmx.begin()) {
+        bmx.setSampling(Adafruit_BME280::MODE_FORCED, Adafruit_BME280::SAMPLING_X1, Adafruit_BME280::SAMPLING_X1, Adafruit_BME280::FILTER_OFF);
+        weatherSensor = WS_BME280; success = true;
+      } else { DLF("WRN: Weather.init(), BME280 (SPI) not found"); }
     #elif WEATHER == BMP280_SPI
-      if (bmx.begin()) { weatherSensor = WS_BMP280; success = true; } else { DLF("WRN: Weather.init(), BMP280 (SPI) not found"); }
+      if (bmx.begin()) {
+        bmx.setSampling(Adafruit_BMP280::MODE_FORCED, Adafruit_BMP280::SAMPLING_X1, Adafruit_BMP280::SAMPLING_X1, Adafruit_BMP280::FILTER_OFF);
+        weatherSensor = WS_BMP280; success = true;
+      } else { DLF("WRN: Weather.init(), BMP280 (SPI) not found"); }
     #else
       #error "Configuration: Setting WEATHER unknown sensor value!"
     #endif
@@ -89,6 +101,7 @@ void Weather::poll() {
           phase = 0;
         break;
       }
+      bmx.takeForcedMeasurement();
 
       // apply a 10 sample rolling average to the ambient temperature
       static uint8_t nanCount = 0;


### PR DESCRIPTION
Makes the same changes to the BME280 & BMP280 sensors configuration as recently made to OCS - use forced mode reads rather than continual to reduce self heating.
Tested BME280 on STM32 Bluepill. Temperature differential from reference sensor was 3.7deg C prior to this change and 0.2deg C when applied.
BMP280 not tested but compiles fine when configured.