### PR TITLE
NV_MB85RC64 for MaxESP4i board

### DIFF
--- a/Config.h
+++ b/Config.h
@@ -138,6 +138,9 @@
 #define TIME_LOCATION_PPS_SENSE       OFF //    OFF, HIGH senses PPS (pulse per second,) signal rising edge, or use LOW for   Option
                                           //         falling edge, or use BOTH for rising and falling edges.
                                           //         Better tracking accuracy especially for Mega2560's w/ceramic resonator.
+// Non-Volitale memory ------------------------------------------
+#define NV_DRIVER              NV_DEFAULT //    NV_DEFAULT, For alternate use NV_AT24C32 on DS3231 module. Use                Option
+                                          //         NV_MB85RC64 on new MaxESP4i                                                       
 
 // STATUS ------------------------------------------------------ see https://onstep.groups.io/g/main/wiki/Configuration_Mount#STATUS
 #define STATUS_MOUNT_LED              OFF //    OFF, ON Flashes proportional to rate of movement or solid on for slews.       Option

--- a/src/HAL/HAL.h
+++ b/src/HAL/HAL.h
@@ -133,6 +133,8 @@
   #define E2END 32767
 #elif NV_DRIVER == NV_MB85RC256
   #define E2END 32767
+#elif NV_DRIVER == NV_MB85RC64
+  #define E2END 8191
 #endif
 #if NV_DRIVER == NV_2416 || NV_DRIVER == NV_2432 || NV_DRIVER == NV_AT24C32 || NV_DRIVER == NV_2464 || NV_DRIVER == NV_24128 || NV_DRIVER == NV_24256
   #if NV_DRIVER == NV_AT24C32
@@ -152,7 +154,7 @@
   #endif
   #include "../lib/nv/NV_24XX.h"
   #define HAL_NV_INIT() nv.init(E2END + 1, NV_CACHED, 0, false, &HAL_Wire, NV_ADDRESS)
-#elif NV_DRIVER == NV_MB85RC256
+#elif NV_DRIVER == NV_MB85RC256 || NV_DRIVER == NV_MB85RC64
   #ifndef NV_ENDURANCE
     #define NV_ENDURANCE NVE_VHIGH
   #endif

--- a/src/lib/Constants.h
+++ b/src/lib/Constants.h
@@ -108,6 +108,8 @@
 #define NV_24256                    5  // 32KB I2C EEPROM AT DEFAULT ADDRESS 0x50
 #define NV_AT24C32                  6  // 4KB I2C EEPROM AT DEFAULT ADDRESS 0x57 (ZS-01 module for instance)
 #define NV_MB85RC256                7  // 32KB I2C FRAM AT DEFAULT ADDRESS 0x50
+#define NV_MB85RC256                7  // 32KB I2C FRAM AT DEFAULT ADDRESS 0x50
+#define NV_MB85RC64                 8  // 8KB I2C FRAM AT DEFAULT ADDRESS 0x50
 
 #define NVE_LOW                     0   // low (< 100K writes)
 #define NVE_MID                     1   // mid (~ 100K writes)

--- a/src/lib/nv/NV_MB85RC.cpp
+++ b/src/lib/nv/NV_MB85RC.cpp
@@ -14,7 +14,7 @@ bool NonVolatileStorageMB85RC::init(uint16_t size, bool cacheEnable, uint16_t wa
   NonVolatileStorage::init(size, cacheEnable, wait, checkEnable, wire, address);
 
   this->wire = wire;
-  this->framAddress = framAddress;
+  framAddress = address;
   wire->begin();
 
   wire->beginTransmission(framAddress);


### PR DESCRIPTION
Added support for NV_MB85RC64 FRAM on MaxESP4i board.