### PR TITLE
Update with mDNS support

### DIFF
--- a/Extended.config.h
+++ b/Extended.config.h
@@ -37,6 +37,7 @@
 // ESP32 VIRTUAL SERIAL BLUETOOTH AND IP COMMAND CHANNELS --------------------------------------------------------------------------
 #define SERIAL_BT_MODE                OFF //    OFF, Use SLAVE to enable the interface (ESP32 only.)                          Option
 #define SERIAL_BT_NAME          "OnStepX" //         "OnStepX", Bluetooth device name.                                        Adjust
+#define MDNS_NAME               "onstepx" //    "onstepx", mDNS device name                                                           Adjust
 #define SERIAL_IP_MODE                OFF //    OFF, WIFI_ACCESS_POINT or WIFI_STATION enables interface (ESP32 only.)        Option
 #define WEB_SERVER                    OFF //    OFF, ON enables Webserver (for Website plugin)                                Option
 

--- a/src/lib/wifi/WifiManager.cpp
+++ b/src/lib/wifi/WifiManager.cpp
@@ -120,6 +120,8 @@ bool WifiManager::init() {
       active = true;
       VLF("MSG: WiFi, initialized");
 
+      if (MDNS.begin(MDNS_NAME)) { VLF("MSG: mDNS started"); }
+
       #if STA_AUTO_RECONNECT == true
         if (settings.stationEnabled) {
           VF("MSG: WiFi, start connection check task (rate 8s priority 7)... ");

--- a/src/lib/wifi/WifiManager.h
+++ b/src/lib/wifi/WifiManager.h
@@ -15,10 +15,12 @@
   #include <WiFi.h>
   #include <WiFiClient.h>
   #include <WiFiAP.h>
+  #include <ESPmDNS.h>
 #elif defined(ESP8266)
   #include <ESP8266WiFi.h>
   #include <WiFiClient.h>
   #include <ESP8266WiFiAP.h>
+  #include <ESP8266mDNS.h>
 #else
   #error "Configuration (Config.h): No Wifi support is present for this device"
 #endif


### PR DESCRIPTION
A simple deployment of mDNS allows accessing OnStep controller in a network with a user friendly DNS name instead of IP address. The host mDNS name is configurable while domain part depends on the network - usually it would be .local. Avahi / Bonjour daemons in Windows 10/11, Mac OS X and most Linux distributions work fine with this mDNS implementation.

OnStepX works well in both modes (access point and station) - tested on ESP32 and ESP32C3 in version 10.19i with Windows 10, Windows 11, Mac OS X and Ubuntu 22.04, also with the web plug-in enabled.