### PR TITLE
PID Typos

### DIFF
--- a/src/lib/axis/motor/servo/feedback/Pid/Pid.cpp
+++ b/src/lib/axis/motor/servo/feedback/Pid/Pid.cpp
@@ -65,7 +65,7 @@ void Pid::selectSlewingParameters() {
     pid->Initialize();
     V(axisPrefix); VL("slewing selected");
     trackingSelected = false;
-    parameterSelect = 100;
+    PidParameterTransitionSteps = 100;
     p = param4;
     i = param5;
     d = param6;

--- a/src/lib/axis/motor/servo/feedback/Pid/Pid.cpp
+++ b/src/lib/axis/motor/servo/feedback/Pid/Pid.cpp
@@ -43,7 +43,7 @@ void Pid::reset() {
   control->out = 0;
   pid->SetMode(QuickPID::Control::automatic);
   trackingSelected = true;
-  selectSlewingParameters();
+  selectTrackingParameters();
 }
 
 void Pid::setControlDirection(int8_t state) {

--- a/src/lib/axis/motor/servo/feedback/Pid/Pid.cpp
+++ b/src/lib/axis/motor/servo/feedback/Pid/Pid.cpp
@@ -53,8 +53,7 @@ void Pid::setControlDirection(int8_t state) {
 // select PID param set for slewing
 void Pid::selectTrackingParameters() {
   if (!trackingSelected) {
-    pid->SetMode(QuickPID::Control::manual);
-    pid->SetMode(QuickPID::Control::automatic);
+    pid->Initialize();
     V(axisPrefix); VL("tracking selected");
     trackingSelected = true;
   }
@@ -63,8 +62,7 @@ void Pid::selectTrackingParameters() {
 // select PID param set for slewing
 void Pid::selectSlewingParameters() {
   if (trackingSelected) {
-    pid->SetMode(QuickPID::Control::manual);
-    pid->SetMode(QuickPID::Control::automatic);
+    pid->Initialize();
     V(axisPrefix); VL("slewing selected");
     trackingSelected = false;
     parameterSelect = 100;

--- a/src/lib/axis/motor/servo/feedback/Pid/Pid.h
+++ b/src/lib/axis/motor/servo/feedback/Pid/Pid.h
@@ -55,9 +55,9 @@ class Pid : public Feedback {
 
       if (!useVariableParameters) {
         if ((long)(millis() - nextSelectIncrementTime) > 0) {
-          if (trackingSelected) parameterSelect--;
-          if (parameterSelect < 0) parameterSelect = 0;
-          variableParameters(parameterSelect);
+          if (trackingSelected) PidParameterTransitionSteps--;
+          if (PidParameterTransitionSteps < 0) PidParameterTransitionSteps = 0;
+          variableParameters(PidParameterTransitionSteps);
           nextSelectIncrementTime = millis() + round(PID_SLEWING_TO_TRACKING_TIME_MS/100.0F);
         }
       }
@@ -75,7 +75,7 @@ class Pid : public Feedback {
 
     char axisPrefix[14] = "MSG: Pid_, ";       // prefix for debug messages
 
-    int parameterSelect = 0;
+    int PidParameterTransitionSteps = 0;
     bool trackingSelected = true;
     unsigned long nextSelectIncrementTime = 0;
 };


### PR DESCRIPTION
1) Use of pid->Initialize() instead of toggling control state
2) In reset() use selectTrackingParameters instead of Slewing Parameters
3) Rename parameterSelect to PidParameterTransitionSteps. This parameter is used when transitioning from slewing parameters to tracking parameters, to make a smoother transition that does not oscillate.