### PR TITLE
Change length of WiFi station credentials to match WiFi specification

### DIFF
--- a/src/Common.h
+++ b/src/Common.h
@@ -18,9 +18,9 @@
 
 #ifdef ESP32
   #if OPERATIONAL_MODE == WIFI && WEB_SERVER == ON
-    #define NV_WIFI_SETTINGS_BASE (NV_LAST+1) // bytes: 451 , 451
+    #define NV_WIFI_SETTINGS_BASE (NV_LAST+1) // bytes: 550 , 550
   #endif
-  #define NV_PEC_BUFFER_BASE    (NV_LAST+452) // bytes: ?   , ? + (PEC_BUFFER_SIZE_LIMIT - 1)
+  #define NV_PEC_BUFFER_BASE    (NV_LAST+551) // bytes: ?   , ? + (PEC_BUFFER_SIZE_LIMIT - 1)
 #else
   #define NV_PEC_BUFFER_BASE      (NV_LAST+1) // bytes: ?   , ? + (PEC_BUFFER_SIZE_LIMIT - 1)
 #endif

--- a/src/lib/wifi/WifiManager.h
+++ b/src/lib/wifi/WifiManager.h
@@ -36,8 +36,8 @@ typedef struct AccessPointSettings {
 } AccessPointSettings;
 
 typedef struct StationSettings {
-  char ssid[32];
-  char pwd[32];
+  char ssid[33];
+  char pwd[64];
   bool dhcpEnabled;
   uint8_t ip[4];
   uint8_t gw[4];
@@ -50,7 +50,7 @@ typedef struct StationSettings {
   // number of wifi stations supported, between 1 and 6
   #define WifiStationCount 3
 #endif
-#define WifiSettingsSize (112 + WifiStationCount*113)
+#define WifiSettingsSize (112 + WifiStationCount*146)
 typedef struct WifiSettings {
   char masterPassword[32];
 


### PR DESCRIPTION
To allow connection to every WiFi network, increase the length of the password to 63 and ssid length to 32 this is the maximum permitted by the WiFi specification.

See the matching pull requests for the web server plugin.