### PR TITLE
Stellarium UTC message fix 

### DIFF
--- a/src/telescope/mount/site/Site.command.cpp
+++ b/src/telescope/mount/site/Site.command.cpp
@@ -156,6 +156,18 @@ bool Site::command(char *reply, char *command, char *parameter, bool *supressFra
     //            Return: 0 failure, 1 success
     if (command[1] == 'G') {
       double hour;
+      char colonIndex = 0xFF;
+      for (char i = 0; i < 6; i++) {
+        if (*(parameter + i) == ':') {
+          colonIndex = i;
+          break;
+        }
+      }
+      if (colonIndex != 0xFF) {
+        for (char i = 0; i < 3; i++){
+          *(parameter + (colonIndex + i)) = 0;
+        }
+      }
       if (convert.tzToDouble(&hour, parameter)) {
         if (hour >= -13.75 || hour <= 12.0) {
           location.timezone = hour;

--- a/src/telescope/mount/site/Site.command.cpp
+++ b/src/telescope/mount/site/Site.command.cpp
@@ -158,14 +158,19 @@ bool Site::command(char *reply, char *command, char *parameter, bool *supressFra
       double hour;
       char colonIndex = 0xFF;
       for (char i = 0; i < 6; i++) {
-        if (*(parameter + i) == ':') {
+        if (parameter[i] == ':') {
           colonIndex = i;
           break;
         }
       }
       if (colonIndex != 0xFF) {
-        for (char i = 0; i < 3; i++){
-          *(parameter + (colonIndex + i)) = 0;
+        char* mm_0 = &parameter[colonIndex + 1];
+        char* mm_1 = &parameter[colonIndex + 2];
+        char* end = &parameter[colonIndex + 3];
+        if (('0' <= *mm_0 && *mm_0 <= '9') && ('0' > *mm_1 || *mm_1 > '9')) {
+          *mm_1 = *mm_0;
+          *mm_0 = '0';
+          *end = 0;
         }
       }
       if (convert.tzToDouble(&hour, parameter)) {


### PR DESCRIPTION
Stellarium sends a bad format at the moment to set the UTC. 

The format that it sends is: 
SG+06:**0**
but this throw an out of range parameter error in debug mode because the acceptance format should be like:
SG+06:00 or SG+06

So, I made a change the minute part in order to fill it with the missing 0. Instead of having "SG+06:0", will change for "SG+06:00"