### PR TITLE
filter.h path fix for linux compilation compatibility

### DIFF
--- a/src/lib/axis/motor/servo/filter/Filter.h
+++ b/src/lib/axis/motor/servo/filter/Filter.h
@@ -2,7 +2,7 @@
 // servo filter
 #pragma once
 
-#include "Kalman\Kalman.h"
-#include "Learning\Learning.h"
-#include "Rolling\Rolling.h"
-#include "Windowing\Windowing.h"
+#include "Kalman/Kalman.h"
+#include "Learning/Learning.h"
+#include "Rolling/Rolling.h"
+#include "Windowing/Windowing.h"


### PR DESCRIPTION
changed backslashes to forward slashes to be able to compile in linux (fixes github actiona automated build)