### PR TITLE
try to avoid spurius interrupts in Quadrature encoders 

### DIFF
--- a/src/lib/encoder/quadrature/Quadrature.cpp
+++ b/src/lib/encoder/quadrature/Quadrature.cpp
@@ -8,60 +8,58 @@
 
 Quadrature *quadratureInstance[9];
 
+// Macro to generate interrupt handlers for each axis
+#define GENERATE_INTERRUPT_HANDLERS(axis_num) \
+  IRAM_ATTR void quadrature_A_Axis##axis_num() { \
+    if (quadratureInstance[axis_num-1]) quadratureInstance[axis_num-1]->handleInterrupt(); \
+  } \
+  IRAM_ATTR void quadrature_B_Axis##axis_num() { \
+    if (quadratureInstance[axis_num-1]) quadratureInstance[axis_num-1]->handleInterrupt(); \
+  }
+
 #if AXIS1_ENCODER == AB
-  IRAM_ATTR void quadrature_A_Axis1() { quadratureInstance[0]->A(AXIS1_ENCODER_A_PIN); }
-  IRAM_ATTR void quadrature_B_Axis1() { quadratureInstance[0]->B(AXIS1_ENCODER_B_PIN); }
+  GENERATE_INTERRUPT_HANDLERS(1)
 #endif
-
 #if AXIS2_ENCODER == AB
-  IRAM_ATTR void quadrature_A_Axis2() { quadratureInstance[1]->A(AXIS2_ENCODER_A_PIN); }
-  IRAM_ATTR void quadrature_B_Axis2() { quadratureInstance[1]->B(AXIS2_ENCODER_B_PIN); }
+  GENERATE_INTERRUPT_HANDLERS(2)
 #endif
-
 #if AXIS3_ENCODER == AB
-  IRAM_ATTR void quadrature_A_Axis3() { quadratureInstance[2]->A(AXIS3_ENCODER_A_PIN); }
-  IRAM_ATTR void quadrature_B_Axis3() { quadratureInstance[2]->B(AXIS3_ENCODER_B_PIN); }
+  GENERATE_INTERRUPT_HANDLERS(3)
 #endif
-
 #if AXIS4_ENCODER == AB
-  IRAM_ATTR void quadrature_A_Axis4() { quadratureInstance[3]->A(AXIS4_ENCODER_A_PIN); }
-  IRAM_ATTR void quadrature_B_Axis4() { quadratureInstance[3]->B(AXIS4_ENCODER_B_PIN); }
+  GENERATE_INTERRUPT_HANDLERS(4)
 #endif
-
 #if AXIS5_ENCODER == AB
-  IRAM_ATTR void quadrature_A_Axis5() { quadratureInstance[4]->A(AXIS5_ENCODER_A_PIN); }
-  IRAM_ATTR void quadrature_B_Axis5() { quadratureInstance[4]->B(AXIS5_ENCODER_B_PIN); }
+  GENERATE_INTERRUPT_HANDLERS(5)
 #endif
-
 #if AXIS6_ENCODER == AB
-  IRAM_ATTR void quadrature_A_Axis6() { quadratureInstance[5]->A(AXIS6_ENCODER_A_PIN); }
-  IRAM_ATTR void quadrature_B_Axis6() { quadratureInstance[5]->B(AXIS6_ENCODER_B_PIN); }
+  GENERATE_INTERRUPT_HANDLERS(6)
 #endif
-
 #if AXIS7_ENCODER == AB
-  IRAM_ATTR void quadrature_A_Axis7() { quadratureInstance[6]->A(AXIS7_ENCODER_A_PIN); }
-  IRAM_ATTR void quadrature_B_Axis7() { quadratureInstance[6]->B(AXIS7_ENCODER_B_PIN); }
+  GENERATE_INTERRUPT_HANDLERS(7)
 #endif
-
 #if AXIS8_ENCODER == AB
-  IRAM_ATTR void quadrature_A_Axis8() { quadratureInstance[7]->A(AXIS8_ENCODER_A_PIN); }
-  IRAM_ATTR void quadrature_B_Axis8() { quadratureInstance[7]->B(AXIS8_ENCODER_B_PIN); }
+  GENERATE_INTERRUPT_HANDLERS(8)
 #endif
-
 #if AXIS9_ENCODER == AB
-  IRAM_ATTR void quadrature_A_Axis9() { quadratureInstance[8]->A(AXIS9_ENCODER_A_PIN); }
-  IRAM_ATTR void quadrature_B_Axis9() { quadratureInstance[8]->B(AXIS9_ENCODER_B_PIN); }
+  GENERATE_INTERRUPT_HANDLERS(9)
 #endif
-
-// for example:
-// Quadrature encoder1(AXIS1_ENCODER_A_PIN, AXIS1_ENCODER_B_PIN, 1);
 
 Quadrature::Quadrature(int16_t APin, int16_t BPin, int16_t axis) {
   if (axis < 1 || axis > 9) return;
 
+  // Check if axis is already assigned
+  if (quadratureInstance[axis - 1] != nullptr) return;
+
   this->APin = APin;
   this->BPin = BPin;
   this->axis = axis;
+  this->count = 0;
+  this->origin = 0;
+  this->error = 0;
+  this->warn = 0;
+  this->ready = false;
+
   quadratureInstance[this->axis - 1] = this;
 }
 
@@ -71,70 +69,80 @@ bool Quadrature::init() {
   pinMode(APin, INPUT_PULLUP);
   pinMode(BPin, INPUT_PULLUP);
 
+  // Read initial states
   stateA = digitalRead(APin);
-  lastA = stateA;
   stateB = digitalRead(BPin);
-  lastB = stateB;
 
+  // Attach interrupts based on axis
+  bool success = false;
   switch (axis) {
     #if AXIS1_ENCODER == AB
       case 1:
         attachInterrupt(digitalPinToInterrupt(APin), quadrature_A_Axis1, CHANGE);
         attachInterrupt(digitalPinToInterrupt(BPin), quadrature_B_Axis1, CHANGE);
+        success = true;
       break;
     #endif
     #if AXIS2_ENCODER == AB
       case 2:
         attachInterrupt(digitalPinToInterrupt(APin), quadrature_A_Axis2, CHANGE);
         attachInterrupt(digitalPinToInterrupt(BPin), quadrature_B_Axis2, CHANGE);
+        success = true;
       break;
     #endif
     #if AXIS3_ENCODER == AB
       case 3:
         attachInterrupt(digitalPinToInterrupt(APin), quadrature_A_Axis3, CHANGE);
         attachInterrupt(digitalPinToInterrupt(BPin), quadrature_B_Axis3, CHANGE);
+        success = true;
       break;
     #endif
     #if AXIS4_ENCODER == AB
       case 4:
         attachInterrupt(digitalPinToInterrupt(APin), quadrature_A_Axis4, CHANGE);
         attachInterrupt(digitalPinToInterrupt(BPin), quadrature_B_Axis4, CHANGE);
+        success = true;
       break;
     #endif
     #if AXIS5_ENCODER == AB
       case 5:
         attachInterrupt(digitalPinToInterrupt(APin), quadrature_A_Axis5, CHANGE);
         attachInterrupt(digitalPinToInterrupt(BPin), quadrature_B_Axis5, CHANGE);
+        success = true;
       break;
     #endif
     #if AXIS6_ENCODER == AB
       case 6:
         attachInterrupt(digitalPinToInterrupt(APin), quadrature_A_Axis6, CHANGE);
         attachInterrupt(digitalPinToInterrupt(BPin), quadrature_B_Axis6, CHANGE);
+        success = true;
       break;
     #endif
     #if AXIS7_ENCODER == AB
       case 7:
         attachInterrupt(digitalPinToInterrupt(APin), quadrature_A_Axis7, CHANGE);
         attachInterrupt(digitalPinToInterrupt(BPin), quadrature_B_Axis7, CHANGE);
+        success = true;
       break;
     #endif
     #if AXIS8_ENCODER == AB
       case 8:
         attachInterrupt(digitalPinToInterrupt(APin), quadrature_A_Axis8, CHANGE);
         attachInterrupt(digitalPinToInterrupt(BPin), quadrature_B_Axis8, CHANGE);
+        success = true;
       break;
     #endif
     #if AXIS9_ENCODER == AB
       case 9:
         attachInterrupt(digitalPinToInterrupt(APin), quadrature_A_Axis9, CHANGE);
         attachInterrupt(digitalPinToInterrupt(BPin), quadrature_B_Axis9, CHANGE);
+        success = true;
       break;
     #endif
   }
 
-  ready = true;
-  return true;
+  ready = success;
+  return success;
 }
 
 int32_t Quadrature::read() {
@@ -158,66 +166,93 @@ void Quadrature::write(int32_t count) {
   interrupts();
 }
 
-// Phase 1: LLHH LLHH
-// Phase 2: LHHL LHHL
-// ...00 01 11 10 00 01 11 10 00 01 11 10...
-
-ICACHE_RAM_ATTR void Quadrature::A(const int16_t pin) {
-  stateA = digitalReadF(pin);
-
-  uint8_t v = stateA*8 + stateB*4 + lastA*2 + lastB;
-  static int16_t dir;
-  switch (v) {
-    case 0b0000: dir = 0; error++; break; // skipped pulse use last dir (way too fast if this is happening)
-    case 0b0001: dir = -1; break;
-    case 0b0010: dir = 1; break;
-    case 0b0011: warn++; break;           // skipped pulse use last dir
-    case 0b0100: dir = 1; break;
-    case 0b0101: dir = 0; error++; break; // skipped pulse use last dir (way too fast if this is happening)
-    case 0b0110: warn++; break;           // skipped pulse use last dir
-    case 0b0111: dir = -1; break;
-    case 0b1000: dir = -1; break;
-    case 0b1001: warn++; break;           // skipped pulse use last dir
-    case 0b1010: dir = 0; error++; break; // skipped pulse use last dir (way too fast if this is happening)
-    case 0b1011: dir = 1; break;
-    case 0b1100: warn++; break;           // skipped pulse use last dir
-    case 0b1101: dir = 1; break;
-    case 0b1110: dir = -1; break;
-    case 0b1111: dir = 0; error++; break; // skipped pulse use last dir (way too fast if this is happening)
-  }
-  count += dir;
-  
-  lastA = stateA;
-  lastB = stateB;
+// Reset error and warning counters
+void Quadrature::clearErrors() {
+  noInterrupts();
+  this->error = 0;
+  this->warn = 0;
+  interrupts();
 }
 
-ICACHE_RAM_ATTR void Quadrature::B(const int16_t pin) {
-  stateB = digitalReadF(pin);
+// Get error counts
+uint32_t Quadrature::getErrors() {
+  uint32_t errors = 0;
+  noInterrupts();
+  errors = this->error;
+  interrupts();
+  return errors;
+}
 
-  uint8_t v = stateA*8 + stateB*4 + lastA*2 + lastB;
-  static int16_t dir;
-  switch (v) {
-    case 0b0000: dir = 0; error++; break;
-    case 0b0001: dir = -1; break;
-    case 0b0010: dir = 1; break;
-    case 0b0011: warn++; break;
-    case 0b0100: dir = 1; break;
-    case 0b0101: dir = 0; error++; break;
-    case 0b0110: warn++; break;
-    case 0b0111: dir = -1; break;
-    case 0b1000: dir = -1; break;
-    case 0b1001: warn++; break;
-    case 0b1010: dir = 0; error++; break;
-    case 0b1011: dir = 1; break;
-    case 0b1100: warn++; break;
-    case 0b1101: dir = 1; break;
-    case 0b1110: dir = -1; break;
-    case 0b1111: dir = 0; error++; break;
+uint32_t Quadrature::getWarnings() {
+  uint32_t warnings = 0;
+  noInterrupts();
+  warnings = this->warn;
+  interrupts();
+  return warnings;
+}
+
+// Quadrature state transition table
+// Phase A: LLHH LLHH LLHH ...
+// Phase B: LHHL LHHL LHHL ...
+// States:  00 01 11 10 00 01 11 10 ... (forward)
+//         00 10 11 01 00 10 11 01 ... (reverse)
+
+static const int8_t QUADRATURE_DECODE_TABLE[16] = {
+  // Bits: [newA][newB][oldA][oldB]
+   0, // 0000 - no change, error
+  -1, // 0001 - 00->01, reverse
+   1, // 0010 - 00->10, forward
+   0, // 0011 - 00->11, invalid transition (warn)
+   1, // 0100 - 01->00, forward
+   0, // 0101 - no change, error
+   0, // 0110 - 01->10, invalid transition (warn)
+  -1, // 0111 - 01->11, reverse
+  -1, // 1000 - 10->00, reverse
+   0, // 1001 - 10->01, invalid transition (warn)
+   0, // 1010 - no change, error
+   1, // 1011 - 10->11, forward
+   0, // 1100 - 11->00, invalid transition (warn)
+   1, // 1101 - 11->01, forward
+  -1, // 1110 - 11->10, reverse
+   0  // 1111 - no change, error
+};
+
+ICACHE_RAM_ATTR void Quadrature::handleInterrupt() {
+  // Read current pin states
+  bool newA = digitalReadF(APin);
+  bool newB = digitalReadF(BPin);
+
+  // Only process if there's actually a state change
+  if (newA == stateA && newB == stateB) {
+    return; // No change, ignore spurious interrupt
   }
-  count += dir;
-  
-  lastA = stateA;
-  lastB = stateB;
+
+  // Create lookup index: [newA][newB][oldA][oldB]
+  uint8_t index = (newA << 3) | (newB << 2) | (stateA << 1) | stateB;
+
+  int8_t direction = QUADRATURE_DECODE_TABLE[index];
+
+  if (direction == 0) {
+    // Check if this is an invalid transition or no-change
+    if (newA != stateA || newB != stateB) {
+      // Invalid transition - likely noise or missed pulses
+      if (index == 0b0011 || index == 0b0110 || index == 0b1001 || index == 0b1100) {
+        warn++; // Two-step transition, recoverable
+      } else {
+        error++; // Impossible transition
+      }
+    } else {
+      error++; // No change but interrupt fired
+    }
+  } else {
+    // Valid transition, update count
+    count += direction;
+  }
+
+  // Update state for next comparison
+  stateA = newA;
+  stateB = newB;
+
 }
 
 #endif

--- a/src/lib/encoder/quadrature/Quadrature.h
+++ b/src/lib/encoder/quadrature/Quadrature.h
@@ -10,31 +10,54 @@
 // for example:
 // Quadrature encoder1(AXIS1_ENCODER_A_PIN, AXIS1_ENCODER_B_PIN, 1);
 
-// Phase 1: LLHH LLHH
-// Phase 2: LHHL LHHL
-// ...00 01 11 10 00 01 11 10 00 01 11 10...
+// Phase A: LLHH LLHH LLHH ...
+// Phase B: LHHL LHHL LHHL ...
+// States:  00 01 11 10 00 01 11 10 ... (forward rotation)
+//         00 10 11 01 00 10 11 01 ... (reverse rotation)
 
 class Quadrature : public Encoder {
   public:
+    // Constructor
     Quadrature(int16_t APin, int16_t BPin, int16_t axis);
+
+    // Initialization
     bool init();
 
+    // Position read/write
     int32_t read();
     void write(int32_t count);
 
-    void A(const int16_t pin);
-    void B(const int16_t pin);
+    // Error management
+    void clearErrors();
+    uint32_t getErrors();
+    uint32_t getWarnings();
+
+    // Interrupt handler (called by both A and B interrupts)
+    void handleInterrupt();
 
   private:
+    // Axis configuration
     int16_t axis;
-
     int16_t APin = OFF;
     int16_t BPin = OFF;
 
-    volatile int16_t stateA;
-    volatile int16_t stateB;
-    volatile int16_t lastA;
-    volatile int16_t lastB;
+    // State tracking (volatile for interrupt safety)
+    volatile bool stateA;
+    volatile bool stateB;
+
+    // Position and error counters (volatile for interrupt safety)
+    volatile int32_t count = 0;
+    volatile uint32_t error = 0;
+    volatile uint32_t warn = 0;
+
+    // Ready flag
+    volatile bool ready = false;
+
+    // Origin offset for position calculations
+    int32_t origin = 0;
+
+  // Note: Removed the separate A() and B() methods since we now use
+  // a single handleInterrupt() method to prevent double-counting
 };
 
 #endif


### PR DESCRIPTION
spurious interrupts lead to errors and stop the motors. I get many errors when there is no state transition which seems like a double handling issue of the same interrupt.

- single interrupt handler
- process interrupts only when there is an actual state change
- lookup table instead of switch
- macro to generate repetitive interrupt handler functions