### PR TITLE
Servo dc calibration

### DIFF
--- a/src/lib/axis/motor/servo/calibration/TrackingVelocity.h
+++ b/src/lib/axis/motor/servo/calibration/TrackingVelocity.h
@@ -13,92 +13,120 @@
   #define CALIBRATE_SERVO_AXIS_SELECT 3  // 0 None, 1 for RA, 2 for DEC, 3 for all
 #endif
 
-#define SERVO_CALIBRATION_TIME_PERIOD 3000                // Seconds per test
-#define SERVO_CALIBRATION_ERROR_THRESHOLD 0.5             // Max error percentage
-#define SERVO_CALIBRATION_START_DUTY_CYCLE 0.001          // Starting duty cycle 0.001%
-#define SERVO_CALIBRATION_IMBALANCE_ERROR_THRESHOLD 1.0   // Max imbalance percentage
-#define SERVO_CALIBRATION_STICTION_REFINE_STEP 0.1        // 0.1% PWM refinement step
-#define SERVO_CALIBRATION_MOTOR_SETTLE_TIME 3000          // seconds to settle after movement
-#define SERVO_CALIBRATION_VELOCITY_SEARCH_MIN_FACTOR 0.1 // Search between stiction * SERVO_CALIBRATION_VELOCITY_SEARCH_MIN_FACTOR and stiction
-#define SERVO_CALIBRATION_PWM_MAX 10.0                    // max value for PWM [0.0 - 100.0]. BE CAUTIOUS!!!
+// Configuration constants
 
-// How much to drop the PWM from the stiction break minimum when starting velocity search.
-// For example, 0.8 means start at 80% of the stictionBreakMin after kickstarting.
-#define SERVO_CALIBRATION_KICKSTART_DROP_FACTOR 1.0f
+#define SERVO_CALIBRATION_START_DUTY_CYCLE 0.1f               // Initial PWM percentage for stiction search
+#define SERVO_CALIBRATION_STOP_DUTY_CYCLE 12.0f               // Maximum allowed PWM percentage
+
+#define SERVO_CALIBRATION_MOTOR_SETTLE_TIME 1000              // ms to wait after stopping motor
+#define SERVO_CALIBRATION_VELOCITY_SETTLE_CHECK_INTERVAL 300  // ms between velocity checks
+#define SERVO_CALIBRATION_TIMEOUT 30000                       // ms before calibration fails
+
+#define SERVO_CALIBRATION_STICTION_REFINE_STEP 0.5f           // PWM % precision for min stiction
+#define SERVO_CALIBRATION_REFINE_MAX_ITERATIONS 10            // Iterations in PWM floor exploration
+#define SERVO_CALIBRATION_VELOCITY_SEARCH_MIN_FACTOR 0.5f     // Min stiction as % of max stiction
+#define SERVO_CALIBRATION_VELOCITY_STABILITY_THRESHOLD 10.0f  // steps/sec^2 for steady state
+
+#define SERVO_CALIBRATION_KICKSTART_DROP_FACTOR 0.9f          // Tracking PWM as % of min stiction
+#define SERVO_CALIBRATION_ERROR_THRESHOLD 5.0f                // Velocity error % for success
+
+#define SERVO_CALIBRATION_IMBALANCE_ERROR_THRESHOLD 2.0f      // Fwd/Rev imbalance warning threshold
+
+#define SERVO_CALIBRATION_MIN_DETECTABLE_VELOCITY 0.1f        // steps/sec minimum movement threshold
+#define SERVO_CALIBRATION_STICTION_SAMPLE_INTERVAL_MS  80                       // short debounce to avoid a single noisy read
+
+// Calibration states
+enum CalibrationState {
+  CALIBRATION_IDLE,
+  CALIBRATION_STICTION_CEILING,
+  CALIBRATION_STICTION_FLOOR,
+  CALIBRATION_VELOCITY_SEARCH,
+  CALIBRATION_CHECK_IMBALANCE
+};
 
 class ServoCalibrateTrackingVelocity {
-  public:
-    ServoCalibrateTrackingVelocity(uint8_t axisNumber);
+public:
+  ServoCalibrateTrackingVelocity(uint8_t axisNumber);
+  void init();
+  void start(float trackingFrequency, long instrumentCoordinateSteps);
+  void updateState(long instrumentCoordinateSteps);
 
-    void init();
+  // Getters for calibration results
+  float getStictionCeiling(bool forward);
+  float getStictionFloor(bool forward);
+  float getTrackingPwm(bool forward);
 
-    // start the calibration process
-    void start(float trackingFrequency, long instrumentCoordinateSteps);
+  bool experimentMode;
+  float experimentPwm;
+  bool enabled;
 
-    // handle calibration state machine
-    void updateState(long instrumentCoordinateSteps);
+  // Debug/status
+  void printReport();
 
-    // has motor settled?
-    bool motorSettled();
+private:
+  // Motor control states
+  enum MotorState {
+    MOTOR_STOPPED,
+    MOTOR_SETTLING,
+    MOTOR_ACCELERATING,
+    MOTOR_RUNNING_STEADY
+  };
 
-    bool experimentMode = false;
-    float experimentPwm = 0.0F;
+  // Core methods
+  void handleMotorState();
+  void processStictionCeiling();
+  void processStictionFloor();
+  void processVelocitySearch();
+  void processImbalanceCheck();
+  void handleCalibrationFailure();
 
-    // get calibration results
-    float getStictionBreakMax(bool forward);
-    float getStictionBreakMin(bool forward);
-    float getTrackingPwm(bool forward);
+  // Helper methods
+  float calculateInstantaneousVelocity();
+  void startSettling();
+  void startTest(float pwm);
+  void setPwm(float pwm);
+  void transitionToRefine();
 
-    // print the report
-    void printReport();
+  // Configuration
+  uint8_t axisNumber;
+  char axisPrefix[16]; // For logging
 
-  private:
-    // set experiment PWM value (bypasses PID)
-    void setExperimentPwm(float pwm);
+  // State tracking
+  CalibrationState calibrationState;
+  MotorState motorState;
+  bool calibrationDirectionIsForward;
 
-    // set experiment PWM and wait the motor to settle
-    void setExperimentPwmAndSettleMotor(float pwm);
+  // Timing and measurements
+  unsigned long currentTime;
+  unsigned long lastStateChangeTime;
+  unsigned long settleStartTime;
+  unsigned long calibrationStepStartTime;
+  unsigned long lastVelocityTime;
+  long currentTicks;
+  long calibrationStepStartTicks;
+  float lastActualVelocity;
+  float lastVelocityMeasurement;
 
-    char axisPrefix[32];
+  // Calibration parameters
+  float calibrationPwm;
+  float calibrationMinPwm;
+  float calibrationMaxPwm;
+  float targetVelocity;
 
-    enum CalibrationState {
-      CALIBRATION_IDLE,
-      CALIBRATION_STICTION_BREAK_MAX_FWD,
-      CALIBRATION_STICTION_REFINE_MIN_FWD,
-      CALIBRATION_VELOCITY_SEARCH_FWD,
-      CALIBRATION_STICTION_BREAK_MAX_REV,
-      CALIBRATION_STICTION_REFINE_MIN_REV,
-      CALIBRATION_VELOCITY_SEARCH_REV,
-      CALIBRATION_PREP_REV,
-      CALIBRATION_CHECK_IMBALANCE
-    };
+  // Results storage
+  float stictionCeilingFwd;
+  float stictionFloorFwd;
+  float trackingPwmFwd;
+  float stictionCeilingRev;
+  float stictionFloorRev;
+  float trackingPwmRev;
 
-    CalibrationState calibrationState;
+  long lastTicks;
+  unsigned long lastCheckTime;
 
-    uint8_t axisNumber;
-
-    unsigned long currentTime;
-
-    // Calibration parameters
-    float calibrationPwm;
-    float stictionBreakMaxFwd;
-    float stictionBreakMinFwd;
-    float trackingPwmFwd;
-    float stictionBreakMaxRev;
-    float stictionBreakMinRev;
-    float trackingPwmRev;
-
-    unsigned long calibrationStartTime;
-    long calibrationStartTicks;
-    float calibrationMinPwm;
-    float calibrationMaxPwm;
-    float targetVelocity;
-    int calibrationPhaseCount;
-
-    // Stiction refinement variables
-    unsigned long settleStartTime;
-    bool waitingForSettle;
-    long currentTicks;
+  bool everMovedFwd;
+  bool everMovedRev;
+  int refineIters;  // guard against infinite loops
 };
 
 #endif


### PR DESCRIPTION
servo dc calibration: refactor calibration stiction ceiling/floor with motor state machine; add timeout & retune constants. Last step (velocity tracking calibration) not implemented yet

Rename terminology & vars

- Stiction Break Max/Min → Stiction Ceiling/Floor (stictionCeiling{Fwd,Rev}, stictionFloor{Fwd,Rev}).

- Logging prefix simplified to Axis{n} VelCal.

New calibration flow (per direction)

- Stiction Ceiling: exponential PWM search (doubling) until first motion.

- Stiction Floor: binary refine between factor * ceiling and ceiling to get the lowest reliable PWM.

- Tracking PWM derived as floor * KICKSTART_DROP_FACTOR (no velocity PID/binary search now).

- Runs FWD then REV, with non-blocking settle between steps.

- Introduce motor state machine: MOTOR_STOPPED → MOTOR_SETTLING → MOTOR_ACCELERATING → MOTOR_RUNNING_STEADY, with helpers: handleMotorState, calculateInstantaneousVelocity, startSettling, startTest, setPwm, transitionToRefine.

- Simplify main calibration states: CALIBRATION_IDLE, CALIBRATION_STICTION_CEILING, CALIBRATION_STICTION_FLOOR, CALIBRATION_CHECK_IMBALANCE.
(Header still declares CALIBRATION_VELOCITY_SEARCH but it’s not implemented/used now.)

- Safety: add SERVO_CALIBRATION_TIMEOUT to bail out and reset on stalled states; centralize PWM clamping.

Constants retuned

More structured MSG/DBG/WARN/ERR logs and a revised printReport()