### PR TITLE
Remove restrictive horizon limits for fork mounts

### DIFF
--- a/src/telescope/mount/limits/Limits.command.cpp
+++ b/src/telescope/mount/limits/Limits.command.cpp
@@ -56,7 +56,9 @@ bool Limits::command(char *reply, char *command, char *parameter, bool *supressF
     if (command[1] == 'h') {
       int16_t deg;
       if (convert.atoi2(parameter, &deg)) {
-        if (deg >= -30.0F && deg <= 30.0F) {
+        // Fork mounts: No restrictions on horizon limits
+        // Other mount types: Apply safety restrictions
+        if (MOUNT_TYPE == FORK || (deg >= -30.0F && deg <= 30.0F)) {
           settings.altitude.min = degToRadF(deg);
           nv.updateBytes(NV_MOUNT_LIMITS_BASE, &settings, sizeof(LimitSettings));
         } else *commandError = CE_PARAM_RANGE;
@@ -70,7 +72,9 @@ bool Limits::command(char *reply, char *command, char *parameter, bool *supressF
     if (command[1] == 'o') {
       int16_t deg;
       if (convert.atoi2(parameter, &deg)) {
-        if (deg >= 60.0F && deg <= 90.0F) {
+        // Fork mounts: No restrictions on overhead limits
+        // Other mount types: Apply safety restrictions
+        if (MOUNT_TYPE == FORK || (deg >= 60.0F && deg <= 90.0F)) {
           settings.altitude.max = degToRadF(deg);
           nv.updateBytes(NV_MOUNT_LIMITS_BASE, &settings, sizeof(LimitSettings));
         } else *commandError = CE_PARAM_RANGE;


### PR DESCRIPTION
## Summary
Removes restrictive horizon and overhead limit validation for fork mounts in the firmware command processing.

## Changes
- **Limits.command.cpp**: Modified \:Sh#\ and \:So#\ command validation to bypass restrictions when \MOUNT_TYPE == FORK\
- Fork mounts can now set horizon limits from -90° to +90°
- Other mount types maintain original safety restrictions (-30° to +30° for horizon, 60° to 90° for overhead)

## Rationale
**Mechanical Protection**: Fork mounts require the ability to park at -90° declination (pointing straight down) at the meridian. In this position, the fork arms provide mechanical protection for the declination axis, preventing external forces from damaging the gears. When the scope is out of park position, the fork arms don't provide this protection, leaving the dec axis vulnerable.

The current restrictive limits (-30° to +30°) prevent this essential safety position, potentially causing gear damage from external forces.

Fork mounts can safely move through the full altitude range from horizon to horizon (-90° to +90°), unlike equatorial mounts which have mechanical limitations requiring restrictive limits.

## Related Changes
This firmware change requires corresponding changes in SmartWebServer to remove web interface restrictions. See related SmartWebServer PR: https://github.com/hjd1964/SmartWebServer/pull/31

## Testing
- Fork mounts: Accept any horizon/overhead limit values via \:Sh#\ and \:So#\ commands
- Other mounts: Maintain original restrictive validation