### PR TITLE
Fix: Wire.begin() missing before setClock() on ESP32 with default I2C pins

### DIFF
--- a/src/pinmaps/Pins.defaults.h
+++ b/src/pinmaps/Pins.defaults.h
@@ -64,7 +64,7 @@
   #if (defined(I2C_SCL_PIN) && I2C_SCL_PIN != OFF) && (defined(I2C_SDA_PIN) && I2C_SDA_PIN != OFF)
     #define WIRE_INIT() HAL_WIRE.begin(I2C_SDA_PIN, I2C_SCL_PIN); HAL_WIRE_SET_CLOCK()
   #else
-    #define WIRE_INIT() HAL_WIRE_SET_CLOCK()
+    #define WIRE_INIT() HAL_WIRE.begin(); HAL_WIRE_SET_CLOCK()
   #endif
 #else
   #if (defined(I2C_SCL_PIN) && I2C_SCL_PIN != OFF) && (defined(I2C_SDA_PIN) && I2C_SDA_PIN != OFF)


### PR DESCRIPTION
When PINMAP uses default I2C pins (I2C_SCL_PIN == OFF, e.g. MaxESP4),
WIRE_INIT() expanded to only HAL_WIRE_SET_CLOCK() without calling
HAL_WIRE.begin() first.

This caused the following error on every boot:
  [E][Wire.cpp:381] setClock(): could not acquire lock

Fix: add HAL_WIRE.begin() before HAL_WIRE_SET_CLOCK() in the
default ESP32 WIRE_INIT() path.

Tested on ESP32-WROOM-32E with MaxESP4 pinmap.
