### PR TITLE
Stabilize tracking rate coordinate snapshot

### DIFF
--- a/src/telescope/mount/Mount.cpp
+++ b/src/telescope/mount/Mount.cpp
@@ -468,20 +468,21 @@ void Mount::poll() {
 
   // get positions 1 (or 30) arc-min ahead and behind the current
   updatePosition(CR_MOUNT_ALL);
-  double altitude = current.a;
-  double declination = current.d;
-  double altitude2 = current.aa2;
+  Coordinate trackingCurrent = current;
+  double altitude = trackingCurrent.a;
+  double declination = trackingCurrent.d;
+  double altitude2 = trackingCurrent.aa2;
 
   // on fast processors calculate true coordinate for a little more accuracy
   #ifndef HAL_SLOW_PROCESSOR
-    transform.mountToTopocentric(&current);
-    if (transform.mountType == ALTAZM) transform.horToEqu(&current); else
-    if (transform.mountType == ALTALT) transform.aaToEqu(&current);
+    transform.mountToTopocentric(&trackingCurrent);
+    if (transform.mountType == ALTAZM) transform.horToEqu(&trackingCurrent); else
+    if (transform.mountType == ALTALT) transform.aaToEqu(&trackingCurrent);
   #endif
 
   Y;
-  Coordinate ahead = current;
-  Coordinate behind = current;
+  Coordinate ahead = trackingCurrent;
+  Coordinate behind = trackingCurrent;
   double trackingRange = DiffRange*trackingRate;
   ahead.h += trackingRange;
   behind.h -= trackingRange;
@@ -553,7 +554,7 @@ void Mount::poll() {
 
   // calculate the Axis2 Dec/Alt tracking rate
   float rate2 = (aheadAxis2 - behindAxis2)/DiffRange2;
-  if (current.pierSide == PIER_SIDE_WEST) rate2 = -rate2;
+  if (trackingCurrent.pierSide == PIER_SIDE_WEST) rate2 = -rate2;
   if (fabs(trackingRateAxis2 - rate2) <= 0.005F) trackingRateAxis2 = (trackingRateAxis2*9.0F + rate2)/10.0F; else trackingRateAxis2 = rate2;
 
   // override for special case of near a celestial pole


### PR DESCRIPTION
## Summary

This PR keeps a local copy of the mount coordinate while `Mount::poll()` calculates tracking rates.

The tracking-rate path updates the shared `current` coordinate, then performs several coordinate conversions and task yields. On non-equatorial mounts, especially Alt/Az, other status/position paths can run during those yields and refresh `current` for a different coordinate request. If that happens mid-calculation, the ahead/behind tracking samples can be based on a different coordinate state than the altitude/declination/pier-side values captured at the start of the calculation.

## Change

- Copy `current` into `trackingCurrent` immediately after `updatePosition(CR_MOUNT_ALL)`.
- Use `trackingCurrent` for:
  - altitude/declination/AltAlt singularity checks
  - the topocentric/equatorial conversion used for ahead/behind samples
  - initial `ahead` and `behind` coordinates
  - pier-side sign handling for axis 2

This keeps the tracking-rate calculation internally consistent across task yields without changing the smoothing, rate limiting, or motor control logic.

## Why

In a local ESP32 Alt/Az setup, tracking occasionally produced a small motor tick and visible telescope shake. Diagnostic logs showed intermittent tracking-rate spikes/zeroed axis samples during normal tracking. After applying this local coordinate snapshot, the same test path no longer showed those spikes in the captured tracking logs, and field tracking behavior improved.

## Testing

- Built successfully in a PlatformIO ESP32 MF OOZOO E4 environment using the same source change.
  - RAM: 63,300 / 327,680 bytes
  - Flash: 1,229,929 / 3,145,728 bytes
- Local field test on an Alt/Az ESP32 controller showed the intermittent tracking spike symptom was no longer reproduced in the captured logs.
- Arduino IDE build was not run in this environment because `arduino-cli` was not available.
