### PR TITLE
Validate home offset command input and range

### DIFF
--- a/src/telescope/mount/home/Home.command.cpp
+++ b/src/telescope/mount/home/Home.command.cpp
@@ -51,12 +51,13 @@ bool Home::command(char *reply, char *command, char *parameter, bool *suppressFr
         V("MSG: Set Axis1 home reverse "); VL(settings.axis1.senseReverse);
         setReversal();
       } else {
-        long l = atol(&parameter[2]);
-        if (l >= -degToArcsecL(180L) || l <= degToArcsecL(180L)) {
+        char *conv_end;
+        long l = strtol(&parameter[2], &conv_end, 10);
+        if (&parameter[2] != conv_end && conv_end[0] == 0 && l >= -degToArcsecL(180L) && l <= degToArcsecL(180L)) {
           settings.axis1.senseOffset = l;
         } else *commandError = CE_PARAM_RANGE;
       }
-      nv().kv().put(nvKey, settings);
+      if (*commandError == CE_NONE) nv().kv().put(nvKey, settings);
       *numericReply = false;
     } else
 
@@ -68,12 +69,13 @@ bool Home::command(char *reply, char *command, char *parameter, bool *suppressFr
         V("MSG: Set Axis2 home reverse "); VL(settings.axis2.senseReverse);
         setReversal();
       } else {
-        long l = atol(&parameter[2]);
-        if (l >= -degToArcsecL(180L) || l <= degToArcsecL(180L)) {
+        char *conv_end;
+        long l = strtol(&parameter[2], &conv_end, 10);
+        if (&parameter[2] != conv_end && conv_end[0] == 0 && l >= -degToArcsecL(180L) && l <= degToArcsecL(180L)) {
           settings.axis2.senseOffset = l;
         } else *commandError = CE_PARAM_RANGE;
       }
-      nv().kv().put(nvKey, settings);
+      if (*commandError == CE_NONE) nv().kv().put(nvKey, settings);
       *numericReply = false;
     } else
 


### PR DESCRIPTION
## Summary

Follow-up to the recent sense offset range fix (9d755d4): the `:hC1,n#` / `:hC2,n#` home offset commands still accept invalid input, because of three issues in the parameter handling.

1. **The range check is always true.** The condition uses `||`:
   ```c
   if (l >= -degToArcsecL(180L) || l <= degToArcsecL(180L)) {
   ```
   Every `long` value satisfies at least one side, so out-of-range values such as `:hC1,9999999#` are stored and written to NV instead of being rejected with `CE_PARAM_RANGE`.

2. **Non-numeric input is silently accepted as 0.** `atol()` returns 0 with no error indication when the parameter is not a number, so a malformed command like `:hC1,abc#` silently resets the stored offset to 0 rather than being rejected. Since these commands can arrive over SHC/serial links where line noise is possible, garbage should not be able to clear a calibrated offset.

3. **Settings are saved to NV even when the command is rejected.** `nv().kv().put()` runs unconditionally, so every rejected command still causes an NV write.

## Changes

- Parse with `strtol()` and require the whole parameter to be consumed (rejects empty and trailing-garbage input).
- Check the range with `&&` so values outside ±648,000 arcsec (±180°) are rejected with `CE_PARAM_RANGE`.
- Only write settings to NV when the command succeeded.

The `R` (reverse) sub-command path is unchanged.

## Testing

Compiled and running on an ESP32 build (10.28w base); `:hC1,n#` with valid values behaves as before, and out-of-range/non-numeric parameters now return the range error without touching the stored offset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
